### PR TITLE
Add CI/CD capability

### DIFF
--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -1,5 +1,4 @@
 name: Idefix CIs
-run-name: Idefix CIs
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Idefix was developped using gitlab CI/CD. This PR proposes an implementation for Github using private hosted runners.