### PR TITLE
 fix the number of ghost cells when using UCT_HLLx EMF reconstruction schemes

### DIFF
--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -17,7 +17,18 @@ jobs:
         with:
           lfs: false
       - run: pre-commit install
-      - run: pre-commit run --all-files
+      - name: Run linter
+        id: linter
+        continue-on-error: true
+        run: pre-commit run --all-files
+      - name: Report linter conclusions
+        if: always()
+        uses: dflydev/check-runs-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          id: linter
+          conclusion: ${{ steps.linter.outcome }}
+          fail-on-error: true
 
   Hydrodynamics:
     needs: Linter

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           id: linter
+          name: Linter
           conclusion: ${{ steps.linter.outcome }}
           fail-on-error: true
 

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -21,15 +21,14 @@ jobs:
         id: linter
         continue-on-error: true
         run: pre-commit run --all-files
-      - name: Report linter conclusions
+      - uses: LouisBrunner/checks-action@v1.1.1
         if: always()
-        uses: dflydev/check-runs-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          id: linter
-          name: Linter
-          conclusion: ${{ steps.linter.outcome }}
-          fail-on-error: true
+          name: Linter checks
+          conclusion: ${{ job.status }}
+          output: |
+            {"summary":${{ steps.test.outputs.summary }}}
 
   Hydrodynamics:
     needs: Linter

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
   pull_request:
-  
+
 env:
   TEST_OPTIONS: -DKokkos_ENABLE_CUDA=ON
-  
+
 jobs:
   Linter:
     # Don't do this in forks

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 env:

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -27,8 +27,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Linter checks
           conclusion: ${{ job.status }}
-          output: |
-            {"summary":${{ steps.linter.outputs.summary }}}
 
   Hydrodynamics:
     needs: Linter

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   packages: read
+  checks: write
   
 jobs:
   Linter:

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -25,7 +25,7 @@ jobs:
         id: linter
         continue-on-error: true
         run: pre-commit run --all-files
-      - uses: LouisBrunner/checks-action@v1.1.1
+      - uses: LouisBrunner/checks-action@v1.5.0
         if: always()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
   pull_request:
-
+  
+permissions:
+  contents: read
+  packages: read
+  
 jobs:
   Linter:
     # Don't do this in forks

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -28,7 +28,7 @@ jobs:
           name: Linter checks
           conclusion: ${{ job.status }}
           output: |
-            {"summary":${{ steps.test.outputs.summary }}}
+            {"summary":${{ steps.linter.outputs.summary }}}
 
   Hydrodynamics:
     needs: Linter

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -6,10 +6,8 @@ on:
       - main
   pull_request:
   
-permissions:
-  contents: read
-  packages: read
-  checks: write
+env:
+  TEST_OPTIONS: -DKokkos_ENABLE_CUDA=ON
   
 jobs:
   Linter:
@@ -24,14 +22,7 @@ jobs:
       - run: pre-commit install
       - name: Run linter
         id: linter
-        continue-on-error: true
         run: pre-commit run --all-files
-      - uses: LouisBrunner/checks-action@v1.5.0
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Linter checks
-          conclusion: ${{ job.status }}
 
   Hydrodynamics:
     needs: Linter

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,32 +8,41 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == 'web'     # execute jobs when created by using Run pipeline button in the GitLab UI, from the project’s CI/CD > Pipelines section.
 
 stages:
-    - checks
-    - deploy
+    - linter
+    - base_checks
+    - advanced_checks
+    - documentation
 
 lint:
-  stage: checks
+  stage: linter
   image: lesurg/idefix:latest
   script:
     - pre-commit install
     - pre-commit run --all-files
 
 HD tests:
-  stage: checks
+  stage: base_checks
   image: lesurg/idefix:latest
   script:
     - cd test
     - ./checks_hydro.sh $TEST_OPTIONS
 
 MHD tests:
-  stage: checks
+  stage: base_checks
   image: lesurg/idefix:latest
   script:
     - cd test
     - ./checks_mhd.sh $TEST_OPTIONS
 
+MPI tests:
+  stage: base_checks
+  image: lesurg/idefix:latest
+  script:
+    - cd test
+    - ./checks_mpi.sh $TEST_OPTIONS
+
 Vector potential tests:
-  stage: checks
+  stage: base_checks
   image: lesurg/idefix:latest
   script:
     - cd test
@@ -47,28 +56,28 @@ MPI tests:
     - ./checks_mpi.sh $TEST_OPTIONS
 
 HighOrder tests:
-  stage: checks
+  stage: advanced_checks
   image: lesurg/idefix:latest
   script:
     - cd test
     - ./checks_highorder.sh $TEST_OPTIONS
 
 SinglePrecision tests:
-  stage: checks
+  stage: advanced_checks
   image: lesurg/idefix:latest
   script:
     - cd test
     - ./checks_singleprecision.sh $TEST_OPTIONS
 
 Examples tests:
-  stage: checks
+  stage: advanced_checks
   image: lesurg/idefix:latest
   script:
     - cd test
     - ./checks_examples.sh $TEST_OPTIONS
 
 Utils tests:
-  stage: checks
+  stage: advanced_checks
   image: lesurg/idefix:latest
   script:
     - cd test
@@ -76,7 +85,7 @@ Utils tests:
 
 pages:
   image: lesurg/idefix-documentation:latest
-  stage: deploy
+  stage: documentation
   script:
     - dir="public"
     - rm -rf $dir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,13 +48,6 @@ Vector potential tests:
     - cd test
     - ./checks_vector_potential.sh $TEST_OPTIONS
 
-MPI tests:
-  stage: checks
-  image: lesurg/idefix:latest
-  script:
-    - cd test
-    - ./checks_mpi.sh $TEST_OPTIONS
-
 HighOrder tests:
   stage: advanced_checks
   image: lesurg/idefix:latest

--- a/src/hydro/MHDsolvers/hllMHD.hpp
+++ b/src/hydro/MHDsolvers/hllMHD.hpp
@@ -24,17 +24,23 @@ void Hydro::HllMHD() {
   constexpr int joffset = (DIR==JDIR) ? 1 : 0;
   constexpr int koffset = (DIR==KDIR) ? 1 : 0;
 
+  int perpExtension=1;
+  if (emf.averaging == ElectroMotiveForce::uct_hll
+      || emf.averaging == ElectroMotiveForce::uct_hlld) {
+        // Need two cells in the perp direction for these schemes
+        perpExtension=2;
+  }
   // extension in perp to the direction of integration, as required by CT.
-  constexpr int iextend = (DIR==IDIR) ? 0 : 1;
+  const int iextend = (DIR==IDIR) ? 0 : perpExtension;
   #if DIMENSIONS > 1
-    constexpr int jextend = (DIR==JDIR) ? 0 : 1;
+    const int jextend = (DIR==JDIR) ? 0 : perpExtension;
   #else
-    constexpr int jextend = 0;
+    const int jextend = 0;
   #endif
   #if DIMENSIONS > 2
-    constexpr int kextend = (DIR==KDIR) ? 0 : 1;
+    const int kextend = (DIR==KDIR) ? 0 : perpExtension;
   #else
-    constexpr int kextend = 0;
+    const int kextend = 0;
   #endif
 
   IdefixArray4D<real> Vc = this->Vc;

--- a/src/hydro/MHDsolvers/hlldMHD.hpp
+++ b/src/hydro/MHDsolvers/hlldMHD.hpp
@@ -24,17 +24,23 @@ void Hydro::HlldMHD() {
   constexpr int joffset = (DIR==JDIR) ? 1 : 0;
   constexpr int koffset = (DIR==KDIR) ? 1 : 0;
 
+  int perpExtension=1;
+  if (emf.averaging == ElectroMotiveForce::uct_hll
+      || emf.averaging == ElectroMotiveForce::uct_hlld) {
+        // Need two cells in the perp direction for these schemes
+        perpExtension=2;
+  }
   // extension in perp to the direction of integration, as required by CT.
-  constexpr int iextend = (DIR==IDIR) ? 0 : 1;
+  const int iextend = (DIR==IDIR) ? 0 : perpExtension;
   #if DIMENSIONS > 1
-    constexpr int jextend = (DIR==JDIR) ? 0 : 1;
+    const int jextend = (DIR==JDIR) ? 0 : perpExtension;
   #else
-    constexpr int jextend = 0;
+    const int jextend = 0;
   #endif
   #if DIMENSIONS > 2
-    constexpr int kextend = (DIR==KDIR) ? 0 : 1;
+    const int kextend = (DIR==KDIR) ? 0 : perpExtension;
   #else
-    constexpr int kextend = 0;
+    const int kextend = 0;
   #endif
 
   IdefixArray4D<real> Vc = this->Vc;

--- a/test/MHD/ResistiveAlfvenWave/setup.cpp
+++ b/test/MHD/ResistiveAlfvenWave/setup.cpp
@@ -19,7 +19,7 @@ void Analysis(DataBlock & data) {
               }, Kokkos::Sum<double>(etot));
 
   #ifdef WITH_MPI
-    MPI_Reduce(MPI_IN_LACE, &etot, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(MPI_IN_PLACE, &etot, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
   #endif
 
   if(idfx::prank == 0) {

--- a/test/checks_hydro.sh
+++ b/test/checks_hydro.sh
@@ -33,43 +33,53 @@ set -e
 options=$@
 
 # HD tests
+TMP_DIR="$(mktemp -d)"
+function finish ()
+{
+  echo $1
+  echo "Cleaning directory $TMP_DIR"
+  cd $TEST_DIR
+  rm -rf $TMP_DIR
+  exit 1
+}
+
 for rep in $rep_HD_list; do
-    TMP_DIR="$(mktemp -d)"
     cp -R $TEST_DIR/HD/$rep/* $TMP_DIR
     cd $TMP_DIR
     echo "***********************************************"
     echo "Configuring  $rep"
     echo "Using $TMP_DIR as working directory"
     echo "***********************************************"
-    rm -f CMakeCache.txt
     def_files=$(ls definitions*.hpp)
     for def in $def_files; do
 
-        cmake $IDEFIX_DIR $options -DIdefix_DEFS=$def|| { echo "!!!! HD $rep failed during configuration"; exit 1; }
+        cmake $IDEFIX_DIR $options -DIdefix_DEFS=$def|| finish "!!!! HD $rep failed during configuration"
         echo "***********************************************"
         echo "Making  $rep with $def"
         echo "***********************************************"
-        make clean; make -j 10 || { echo "!!!! HD $rep failed during compilation with $def"; exit 1; }
+        make -j 8 || finish "!!!! HD $rep failed during compilation with $def"
 
         ini_files=$(ls *.ini)
         for ini in $ini_files; do
             echo "***********************************************"
             echo "Running  $rep with $ini"
             echo "***********************************************"
-            ./idefix -i $ini -nolog || { echo "!!!! HD $rep failed running with $def and $ini"; exit 1; }
+            ./idefix -i $ini -nolog || finish "!!!! HD $rep failed running with $def and $ini"
 
             cd python
             echo "***********************************************"
             echo "Testing  $rep with $ini and $def"
             echo "***********************************************"
-            python3 testidefix.py -noplot || { echo "!!!! HD $rep failed validation with $def and $ini"; exit 1; }
+            python3 testidefix.py -noplot || finish "!!!! HD $rep failed validation with $def and $ini"
             cd ..
         done
-        make clean
         rm -f *.vtk *.dbl *.dmp
     done
     echo "***********************************************"
     echo "Cleaning  $rep in $TMP_DIR"
     echo "***********************************************"
-    rm -rf $TMP_DIR
+   rm -rf *.vtk *.dbl *.dmp *.ini python CMakeLists.txt
 done
+echo "Test was successfull"
+cd $TEST_DIR
+rm -rf $TMP_DIR

--- a/test/checks_mhd.sh
+++ b/test/checks_mhd.sh
@@ -32,40 +32,52 @@ echo $IDEFIX_DIR
 set -e
 options=$@
 
+function finish ()
+{
+  echo $1
+  echo "Cleaning directory $TMP_DIR"
+  cd $TEST_DIR
+  rm -rf $TMP_DIR
+  exit 1
+}
 
 # MHD tests
 for rep in $rep_MHD_list; do
-    cp -R $TEST_DIR/MHD/$rep $TMP_DIR
-    cd $TMP_DIR/$rep
+    cp -R $TEST_DIR/MHD/$rep/* $TMP_DIR
+    cd $TMP_DIR
     echo "***********************************************"
     echo "Configuring  $rep"
     echo "Using $TMP_DIR/$rep as working directory"
     echo "***********************************************"
-    rm -f CMakeCache.txt
     def_files=$(ls definitions*.hpp)
     for def in $def_files; do
-        cmake $IDEFIX_DIR $options -DIdefix_DEFS=$def|| { echo "!!!! MHD $rep failed during configuration"; exit 1; }
+        cmake $IDEFIX_DIR $options -DIdefix_DEFS=$def|| finish "!!!! MHD $rep failed during configuration"
         echo "***********************************************"
         echo "Making  $rep with $def"
         echo "***********************************************"
-        make clean; make -j 10 || { echo "!!!! MHD $rep failed during compilation with $def"; exit 1; }
+        make -j 8 || finish "!!!! MHD $rep failed during compilation with $def"
 
         ini_files=$(ls *.ini)
         for ini in $ini_files; do
             echo "***********************************************"
             echo "Running  $rep with $ini"
             echo "***********************************************"
-            ./idefix -i $ini -nolog || { echo "!!!! MHD $rep failed running with $def and $ini"; exit 1; }
+            ./idefix -i $ini -nolog || finish "!!!! MHD $rep failed running with $def and $ini"
 
             cd python
             echo "***********************************************"
             echo "Testing  $rep with $ini and $def"
             echo "***********************************************"
-            python3 testidefix.py -noplot -i ../$ini || { echo "!!!! MHD $rep failed validation with $def and $ini"; exit 1; }
+            python3 testidefix.py -noplot -i ../$ini || finish "!!!! MHD $rep failed validation with $def and $ini"
             cd ..
         done
+        rm -f *.vtk *.dbl *.dmp
     done
+    echo "***********************************************"
+    echo "Cleaning  $TMP_DIR"
+    echo "***********************************************"
+   rm -rf *.vtk *.dbl *.dmp *.ini python CMakeLists.txt
 done
-
-echo "Cleaning temporary directory $TMP_DIR"
+echo "Test was successfull"
+cd $TEST_DIR
 rm -rf $TMP_DIR

--- a/test/checks_mpi.sh
+++ b/test/checks_mpi.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 rep_2D_mpi_list="HD/MachReflection HD/ViscousFlowPastCylinder HD/FargoPlanet MHD/OrszagTang"
-rep_3D_mpi_list="MHD/AmbipolarCshock3D MHD/AxisFluxTube MHD/LinearWaveTest MHD/FargoMHDSpherical MHD/OrszagTang3D"
+rep_3D_mpi_list="MHD/AxisFluxTube MHD/LinearWaveTest MHD/FargoMHDSpherical MHD/OrszagTang3D"
+rep_3D_noX3_list="MHD/AmbipolarCshock3D"
 
 # refer to the parent dir of this file, wherever this is called from
 # a python equivalent is e.g.
@@ -10,13 +11,20 @@ rep_3D_mpi_list="MHD/AmbipolarCshock3D MHD/AxisFluxTube MHD/LinearWaveTest MHD/F
 # TEST_DIR = pathlib.Path(__file__).parent
 TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TMP_DIR="$(mktemp -d)"
-mkdir $TMP_DIR/HD
-mkdir $TMP_DIR/MHD
 
 function resolve_path {
     # resolve relative paths
     # work around the fact that `realpath` is not bundled with every UNIX distro
     echo "`cd "$1";pwd`"
+}
+
+function finish ()
+{
+  echo $1
+  echo "Cleaning directory $TMP_DIR"
+  cd $TEST_DIR
+  rm -rf $TMP_DIR
+  exit 1
 }
 
 target_dir=$(resolve_path $TEST_DIR/..)
@@ -38,67 +46,95 @@ options=$@
 
 # 2D MPI tests
 for rep in $rep_2D_mpi_list; do
-    cp -R $TEST_DIR/$rep $TMP_DIR/$rep
-    cd $TMP_DIR/$rep
+    cp -R $TEST_DIR/$rep/* $TMP_DIR
+    cd $TMP_DIR
     echo "***********************************************"
     echo "Configuring  $rep"
     echo "Using $TMP_DIR/$rep as working directory"
     echo "***********************************************"
-    rm -f CMakeCache.txt
-    cmake $IDEFIX_DIR -DIdefix_MPI=ON  $options
+    cmake $IDEFIX_DIR -DIdefix_MPI=ON  $options || finish "!!!! MPI $rep failed during configuration"
     echo "***********************************************"
     echo "Making  $rep"
     echo "***********************************************"
-    make clean; make -j 10
+    make -j 8 || finish "!!!! MPI $rep failed during compilation"
 
     ini_files=$(ls *.ini)
     for ini in $ini_files; do
         echo "***********************************************"
         echo "Running  $rep with $ini"
         echo "***********************************************"
-        mpirun -np 4 ./idefix -i $ini -dec 2 2 -nolog
+        mpirun -np 4 ./idefix -i $ini -dec 2 2 -nolog || finish "!!!! MPI $rep failed during runtime with $ini"
 
         cd python
         echo "***********************************************"
         echo "Testing  $rep with $ini"
         echo "***********************************************"
-        python3 testidefix.py -noplot -i ../$ini
+        python3 testidefix.py -noplot -i ../$ini || finish "!!!! MPI $rep failed during validation"
         cd ..
     done
-    make clean
-    rm -f *.vtk *.dbl *.dmp
+   rm -rf *.vtk *.dbl *.dmp *.ini python CMakeLists.txt
 done
 
 # MHD tests
-for rep in $rep_3D_mpi_list; do
-    cp -R $TEST_DIR/$rep $TMP_DIR/$rep
-    cd $TMP_DIR/$rep
+for rep in $rep_3D_noX3_list; do
+    cp -R $TEST_DIR/$rep/* $TMP_DIR
+    cd $TMP_DIR
     echo "***********************************************"
     echo "Configuring  $rep"
     echo "Using $TMP_DIR/$rep as working directory"
     echo "***********************************************"
-    rm -f CMakeCache.txt
-    cmake $IDEFIX_DIR -DIdefix_MPI=ON $options
+    cmake $IDEFIX_DIR -DIdefix_MPI=ON $options || finish "!!!! MPI $rep failed during configuration"
     echo "***********************************************"
     echo "Making  $rep"
     echo "***********************************************"
-    make clean; make -j 10
+    make -j 8 || finish "!!!! MPI $rep failed during compilation"
 
     ini_files=$(ls *.ini)
     for ini in $ini_files; do
         echo "***********************************************"
         echo "Running  $rep with $ini"
         echo "***********************************************"
-        mpirun -np 8 ./idefix -i $ini -dec 2 2 2 -nolog
+        mpirun -np 4 ./idefix -i $ini -dec 2 2 1 -nolog || finish "!!!! MPI $rep failed during runtime with $ini"
 
         cd python
         echo "***********************************************"
         echo "Testing  $rep with $ini"
         echo "***********************************************"
-        python3 testidefix.py -noplot -i ../$ini
+        python3 testidefix.py -noplot || finish "!!!! MPI $rep failed during validation"
         cd ..
     done
+   rm -rf *.vtk *.dbl *.dmp *.ini python CMakeLists.txt
+    cd $TEST_DIR
+done
 
+for rep in $rep_3D_mpi_list; do
+    cp -R $TEST_DIR/$rep/* $TMP_DIR
+    cd $TMP_DIR
+    echo "***********************************************"
+    echo "Configuring  $rep"
+    echo "Using $TMP_DIR/$rep as working directory"
+    echo "***********************************************"
+    cmake $IDEFIX_DIR -DIdefix_MPI=ON $options || finish "!!!! MPI $rep failed during configuration"
+    echo "***********************************************"
+    echo "Making  $rep"
+    echo "***********************************************"
+    make -j 8 || finish "!!!! MPI $rep failed during compilation"
+
+    ini_files=$(ls *.ini)
+    for ini in $ini_files; do
+        echo "***********************************************"
+        echo "Running  $rep with $ini"
+        echo "***********************************************"
+        mpirun -np 8 ./idefix -i $ini -dec 2 2 2 -nolog || finish "!!!! MPI $rep failed during runtime with $ini"
+
+        cd python
+        echo "***********************************************"
+        echo "Testing  $rep with $ini"
+        echo "***********************************************"
+        python3 testidefix.py -noplot -i ../$ini  || finish "!!!! MPI $rep failed during validation"
+        cd ..
+    done
+   rm -rf *.vtk *.dbl *.dmp *.ini python CMakeLists.txt
     cd $TEST_DIR
 done
 
@@ -106,30 +142,29 @@ done
 rep="HD/SedovBlastWave"
 
 ## Cartesian blast
-cp -R $TEST_DIR/$rep $TMP_DIR/$rep
-cd $TMP_DIR/$rep
+cp -R $TEST_DIR/$rep/* $TMP_DIR
+cd $TMP_DIR
 echo "***********************************************"
 echo "Configuring  $rep"
 echo "Using $TMP_DIR/$rep as working directory"
 echo "***********************************************"
-rm -f CMakeCache.txt
-cmake $IDEFIX_DIR -DIdefix_MPI=ON $options
+cmake $IDEFIX_DIR -DIdefix_MPI=ON -DIdefix_MHD=OFF $options || finish "!!!! MPI $rep failed during configuration"
 echo "***********************************************"
 echo "Making  $rep"
 echo "***********************************************"
-make clean; make -j 10
+make -j 8 || finish "!!!! MPI $rep failed during compilation"
 
 ini="idefix.ini"
 echo "***********************************************"
 echo "Running  $rep with $ini"
 echo "***********************************************"
-mpirun -np 8 ./idefix -i $ini -dec 2 2 2 -nolog
+mpirun -np 8 ./idefix -i $ini -dec 2 2 2 -nolog || finish "!!!! MPI $rep failed during runtime with $ini"
 
 cd python
 echo "***********************************************"
 echo "Testing  $rep with $ini"
 echo "***********************************************"
-python3 testidefix.py -noplot -i ../$ini
+python3 testidefix.py -noplot -i ../$ini  || finish "!!!! MPI $rep failed during validation"
 cd ..
 
 ## Spherical blast
@@ -137,27 +172,26 @@ echo "***********************************************"
 echo "Configuring  $rep in spherical geometry"
 echo "Using $TMP_DIR/$rep as working directory"
 echo "***********************************************"
-rm -f CMakeCache.txt
-cmake $IDEFIX_DIR -DIdefix_MPI=ON -DIdefix_DEFS=definitions-spherical.hpp $options
+
+cmake $IDEFIX_DIR -DIdefix_MPI=ON -DIdefix_MHD=OFF -DIdefix_DEFS=definitions-spherical.hpp $options || finish "!!!! MPI $rep failed during configuration"
 echo "***********************************************"
 echo "Making  $rep"
 echo "***********************************************"
-make clean; make -j 10
+make -j 8 || finish "!!!! MPI $rep failed during compilation"
 
 ini="idefix-spherical.ini"
 echo "***********************************************"
 echo "Running  $rep with $ini"
 echo "***********************************************"
-mpirun -np 8 ./idefix -i $ini -dec 2 2 2 -nolog
+mpirun -np 8 ./idefix -i $ini -dec 2 2 2 -nolog || finish "!!!! MPI $rep failed during runtime with $ini"
 
 cd python
 echo "***********************************************"
 echo "Testing  $rep with $ini"
 echo "***********************************************"
-python3 testidefix.py -noplot -i ../$ini
+python3 testidefix.py -noplot -i ../$ini  || finish "!!!! MPI $rep failed during validation"
 
+## done
+echo "Test was successfull"
 cd $TEST_DIR
-
-
-echo "Cleaning temporary directory $TMP_DIR"
 rm -rf $TMP_DIR

--- a/test/checks_utils.sh
+++ b/test/checks_utils.sh
@@ -34,43 +34,52 @@ options=$@
 rep="utils/lookupTable"
 
 TMP_DIR="$(mktemp -d)"
+function finish ()
+{
+  echo $1
+  echo "Cleaning directory $TMP_DIR"
+  cd $TEST_DIR
+  rm -rf $TMP_DIR
+  exit 1
+}
+
 cp -R $TEST_DIR/$rep/* $TMP_DIR
 cd $TMP_DIR
 echo "***********************************************"
 echo "Making numpy test files"
 echo "***********************************************"
-python3 makeNpy.py
+python3 makeNpy.py || finish "!!!! can't make numpy test file"
 echo "***********************************************"
 echo "Configuring  $rep"
 echo "Using $TMP_DIR/$rep as working directory"
 echo "***********************************************"
-rm -f CMakeCache.txt
-cmake $IDEFIX_DIR -DIdefix_MPI=ON  $options
+cmake $IDEFIX_DIR -DIdefix_MPI=ON  $options || finish "!!!! Example $rep failed during configuration"
 echo "***********************************************"
 echo "Making  $rep"
 echo "***********************************************"
-make clean; make -j 10
-mpirun -np 4 ./idefix
+make -j 8 || finish  "!!!! Test $rep failed during compilation"
+mpirun -np 4 ./idefix || finish  "!!!! Test $rep failed during runtime"
+rm -rf *.vtk *.dbl *.dmp *.ini python
+
 cd $TEST_DIR
-rm -rf $TMP_DIR
 
 
 # Validate DumpImage
 rep="utils/dumpImage"
 
-TMP_DIR="$(mktemp -d)"
 cp -R $TEST_DIR/$rep/* $TMP_DIR
 cd $TMP_DIR
 echo "***********************************************"
 echo "Configuring  $rep"
 echo "Using $TMP_DIR/$rep as working directory"
 echo "***********************************************"
-rm -f CMakeCache.txt
-cmake $IDEFIX_DIR  $options
+cmake $IDEFIX_DIR  $options || finish "!!!! Example $rep failed during configuration"
 echo "***********************************************"
 echo "Making  $rep"
 echo "***********************************************"
-make clean; make -j 10
-./idefix
+make -j 8 || finish  "!!!! Test $rep failed during compilation"
+./idefix || finish  "!!!! Test $rep failed during runtime"
+
+echo "Test was successfull"
 cd $TEST_DIR
 rm -rf $TMP_DIR

--- a/test/checks_vector_potential.sh
+++ b/test/checks_vector_potential.sh
@@ -32,41 +32,51 @@ echo $IDEFIX_DIR
 set -e
 options=$@
 
+function finish ()
+{
+  echo $1
+  echo "Cleaning directory $TMP_DIR"
+  cd $TEST_DIR
+  rm -rf $TMP_DIR
+  exit 1
+}
 
 # MHD+Vector potential tests
 for rep in $rep_MHD_list; do
-    cp -R $TEST_DIR/MHD/$rep $TMP_DIR
-    cd $TMP_DIR/$rep
+    cp -R $TEST_DIR/MHD/$rep/* $TMP_DIR
+    cd $TMP_DIR
     echo "***********************************************"
     echo "Configuring  $rep"
     echo "Using $TMP_DIR/$rep as working directory"
     echo "***********************************************"
-    rm -f CMakeCache.txt
+
     def_files=$(ls definitions*.hpp)
     for def in $def_files; do
-        cmake $IDEFIX_DIR $options -DIdefix_EVOLVE_VECTOR_POTENTIAL=ON -DIdefix_DEFS=$def|| { echo "!!!! MHD $rep failed during configuration"; exit 1; }
+        cmake $IDEFIX_DIR $options -DIdefix_EVOLVE_VECTOR_POTENTIAL=ON -DIdefix_DEFS=$def|| finish "!!!! MHD $rep failed during configuration"
         echo "***********************************************"
         echo "Making  $rep with $def"
         echo "***********************************************"
-        make clean; make -j 10 || { echo "!!!! MHD $rep failed during compilation with $def"; exit 1; }
+        make -j 8 || finish "!!!! MHD $rep failed during compilation with $def"
 
         ini_files=$(ls *.ini)
         for ini in $ini_files; do
             echo "***********************************************"
             echo "Running  $rep with $ini"
             echo "***********************************************"
-            ./idefix -i $ini -nolog || { echo "!!!! MHD $rep failed running with $def and $ini"; exit 1; }
+            ./idefix -i $ini -nolog || finish "!!!! MHD $rep failed running with $def and $ini"
 
             cd python
             echo "***********************************************"
             echo "Testing  $rep with $ini and $def"
             echo "***********************************************"
-            python3 testidefix.py -noplot || { echo "!!!! MHD $rep failed validation with $def and $ini"; exit 1; }
+            python3 testidefix.py -noplot || finish "!!!! MHD $rep failed validation with $def and $ini"
             cd ..
         done
     done
+   rm -rf *.vtk *.dbl *.dmp *.ini python CMakeLists.txt
     cd $TEST_DIR
 done
 
-echo "Cleaning temporary directory $TMP_DIR"
+echo "Test was successfull"
+cd $TEST_DIR
 rm -rf $TMP_DIR


### PR DESCRIPTION
Some tests of the UCT_HLLx EMF reconstruction schemes led to inconsistent results with varying domain decomposition. This is due to the fact that these schemes require 2 ghost cells in the direction perpendicular to the sweep in the 1D Riemann solver, instead of 1.
This MR fixes this issue, and restores consistent results with domain decomposition and MPI