### PR TITLE
Fix divB runaway with axis and domain decomposition along phi

### DIFF
--- a/src/hydro/axis.cpp
+++ b/src/hydro/axis.cpp
@@ -117,6 +117,7 @@ void Axis::SymmetrizeEx1Side(int jref) {
       });
     if(needMPIExchange) {
       #ifdef WITH_MPI
+        Kokkos::fence();
         // sum along all of the processes on the same r
         MPI_Allreduce(MPI_IN_PLACE, Ex1Avg.data(), data->np_tot[IDIR], realMPI,
                       MPI_SUM, data->mygrid->AxisComm);
@@ -159,60 +160,56 @@ void Axis::RegularizeCurrentSide(int side) {
   // Compute the values of Jx, Jy and Jz that are consistent for all cells touching the axis
   #if DIMENSIONS == 3
     IdefixArray4D<real> J = hydro->J;
-    int jref = 0;
+    IdefixArray4D<real> Vs = hydro->Vs;
+    int js = 0;
+    int jc = 0;
     int sign = 0;
-
     if(side == left) {
-      jref = data->beg[JDIR];
+      js = data->beg[JDIR];
+      jc = data->beg[JDIR];
       sign = 1;
     }
     if(side == right) {
-      jref = data->end[JDIR];
+      js = data->end[JDIR];
+      jc = data->end[JDIR]-1;
       sign = -1;
     }
-    IdefixArray2D<real> JAvg = this->JAvg;
-    IdefixArray1D<real> phi = data->x[KDIR];
+    IdefixArray1D<real> BAvg = this->Ex1Avg;
+    IdefixArray1D<real> x2 = data->x[JDIR];
+    IdefixArray1D<real> x1 = data->x[IDIR];
+    IdefixArray1D<real> dx3 = data->dx[KDIR];
 
-
-
-    idefix_for("J_ini",0,data->np_tot[IDIR],0,3,
-          KOKKOS_LAMBDA(int i, int n) {
-            JAvg(i,n) = ZERO_F;
+    idefix_for("B_ini",0,data->np_tot[IDIR],
+          KOKKOS_LAMBDA(int i) {
+            BAvg(i) = ZERO_F;
     });
-    idefix_for("JHorizontal_compute",data->beg[KDIR],data->end[KDIR],0,data->np_tot[IDIR],
+    idefix_for("Compute_Bcirculation",data->beg[KDIR],data->end[KDIR],0,data->np_tot[IDIR],
         KOKKOS_LAMBDA(int k,int i) {
-          real Jthmid = sign*(J(JDIR,k  ,jref-1,i) +
-                              J(JDIR,k  ,jref  ,i) +
-                              J(JDIR,k+1,jref-1,i) +
-                              J(JDIR,k+1,jref  ,i)) / 4.0;
-
-          real Jphimid = J(KDIR,k, jref, i);
-
-          Kokkos::atomic_add(&JAvg(i,IDIR), Jthmid * cos(phi(k)) - Jphimid * sin(phi(k)));
-          Kokkos::atomic_add(&JAvg(i,JDIR), Jthmid * sin(phi(k)) + Jphimid * cos(phi(k)));
-          Kokkos::atomic_add(&JAvg(i,KDIR), J(IDIR,k,jref+sign,i)); // We pick up the radial current
-                                                                    // in the active zones
+          Kokkos::atomic_add(&BAvg(i), Vs(BX3s,k,jc,i)*dx3(k) ); // Compute the circulation of
+                                                                 // Bphi around the pole
     });
 
     if(needMPIExchange) {
       #ifdef WITH_MPI
+        Kokkos::fence();
         // sum along all of the processes on the same r
-        MPI_Allreduce(MPI_IN_PLACE, JAvg.data(), 3*data->np_tot[IDIR], realMPI,
+        MPI_Allreduce(MPI_IN_PLACE, BAvg.data(), data->np_tot[IDIR], realMPI,
                       MPI_SUM, data->mygrid->AxisComm);
       #endif
     }
 
     const int ncells=data->mygrid->np_int[KDIR];
 
+    real deltaPhi = data->mygrid->xend[KDIR] - data->mygrid->xbeg[KDIR];
+
+    // Use the circulation around the pole of Bphi to determine Jr on the pole:
+    // Delta phi r^2(1-cos theta) Jr = int r sin(theta) Bphi dphi
+
     idefix_for("fixJ",0,data->np_tot[KDIR],0,data->np_tot[IDIR],
         KOKKOS_LAMBDA(int k,int i) {
-          real Jx = JAvg(i,IDIR) / ((real) ncells*sign);
-          real Jy = JAvg(i,JDIR) / ((real) ncells*sign);
-          real Jz = JAvg(i,KDIR) / ((real) ncells);
-
-          J(IDIR, k,jref,i) = Jz;
-          J(JDIR, k,jref,i) = cos(phi(k))*Jx + sin(phi(k))*Jy;
-          // There is nothing along KDIR since Jphi is never localised on the axis.
+          real th = x2(jc);
+          real fact = sign*sin(th)/(deltaPhi*x1(i)*(1-cos(th)));
+          J(IDIR, k,js,i) = BAvg(i)*fact;
         });
 
   #endif // DIMENSIONS
@@ -257,15 +254,21 @@ void Axis::FixBx2sAxis(int side) {
     IdefixArray2D<real> BAvg = this->BAvg;
     IdefixArray1D<real> phi = data->x[KDIR];
 
-    int jref = 0;
+    int jin = 0;
+    int jout = 0;
+    int jaxe = 0;
     int sign = 0;
 
     if(side == left) {
-      jref = data->beg[JDIR];
+      jin = data->beg[JDIR];
+      jout = jin-1;
+      jaxe = jin;
       sign = 1;
     }
     if(side == right) {
-      jref = data->end[JDIR];
+      jin = data->end[JDIR]-1;
+      jout = jin+1;
+      jaxe = jout;
       sign = -1;
     }
 
@@ -275,8 +278,8 @@ void Axis::FixBx2sAxis(int side) {
     });
     idefix_for("BHorizontal_compute",data->beg[KDIR],data->end[KDIR],0,data->np_tot[IDIR],
         KOKKOS_LAMBDA(int k,int i) {
-          real Bthmid = sign*HALF_F*(Vs(BX2s,k,jref-1,i) + Vs(BX2s,k,jref+1,i));
-          real Bphimid = HALF_F*(Vs(BX3s,k,jref-1,i) + Vs(BX3s,k,jref,i));
+          real Bthmid = sign*HALF_F*(Vs(BX2s,k,jaxe-1,i) + Vs(BX2s,k,jaxe+1,i));
+          real Bphimid = HALF_F*(Vs(BX3s,k,jin,i) + Vs(BX3s,k,jout,i));
           //Bthmid = 0.0;
           //Bphimid = 0.0;
 
@@ -284,6 +287,7 @@ void Axis::FixBx2sAxis(int side) {
           Kokkos::atomic_add(&BAvg(i,JDIR), Bthmid * sin(phi(k)) + Bphimid * cos(phi(k)));
     });
     if(needMPIExchange) {
+      Kokkos::fence();
       #ifdef WITH_MPI
         // sum along all of the processes on the same r
         MPI_Allreduce(MPI_IN_PLACE, BAvg.data(), 2*data->np_tot[IDIR], realMPI,
@@ -294,10 +298,10 @@ void Axis::FixBx2sAxis(int side) {
 
     idefix_for("fixBX2s",data->beg[KDIR],data->end[KDIR],0,data->np_tot[IDIR],
         KOKKOS_LAMBDA(int k,int i) {
-          real Bx = BAvg(i,IDIR) / ((real) ncells*sign);
-          real By = BAvg(i,JDIR) / ((real) ncells*sign);
+          real Bx = BAvg(i,IDIR) / ((real) ncells);
+          real By = BAvg(i,JDIR) / ((real) ncells);
 
-          Vs(BX2s,k,jref,i) = cos(phi(k))*Bx + sin(phi(k))*By;
+          Vs(BX2s,k,jaxe,i) = sign*(cos(phi(k))*Bx + sin(phi(k))*By);
         });
   #endif // DIMENSIONS
 }

--- a/src/hydro/axis.hpp
+++ b/src/hydro/axis.hpp
@@ -18,7 +18,7 @@ class Hydro;
 class DataBlock;
 
 // Whether we use athena++ procedure to regularise BX2s
-#define AXIS_BX2S_USE_ATHENA_REGULARISATION
+//#define AXIS_BX2S_USE_ATHENA_REGULARISATION
 
 class Axis {
  public:

--- a/src/hydro/calcCurrent.cpp
+++ b/src/hydro/calcCurrent.cpp
@@ -154,9 +154,9 @@ void Hydro::CalcCurrent() {
 
   // Regularize the current along the axis in cases where an axis is present.
   // This feature is not yet ready, so it is commented out
-  //if(this->haveAxis) {
-  //  this->myAxis.RegularizeCurrent();
-  //}
+  if(this->haveAxis) {
+    this->myAxis.RegularizeCurrent();
+  }
 
   idfx::popRegion();
 }


### PR DESCRIPTION
When the spherical axis is included, every cell around the axis shares a common edge, directed along x1. Hence, the electric field and current (both of which are localised on cell edges) along the axis should be the same for all of the cells having an edge along the axis.

The determination of this "axis" value is done through an averaging of all the cell values (a "gather") which is then overwritten to every cell. When a domain decomposition along phi is used, this involves first computing the local average of the current subdomain, followed by an MPI_AllReduce between the procs sharing the axis.

In some circumstances, the MPI_Allreduce starts before the code has finished computing the cell average. This might happen on some GPUs for some MPI Cuda-aware implementations where MPI is running on a separate GPU stream. As a result, some domains may not end up with the same value for the edge field (being E or J).

Since contained transport works only if the edge values are consistent across cells, the end result of this "to early" MPI_AllReduce issue is that divB possibly blow up at the interface between sub-domain along the axis.
This MR fixes that issue, adding Kokkos::fence before all MPI_AllReduce.

In addition, it proposes a way to compute the current along the axis using the circulation of Bphi around the axis.
Finally, it reverts back to the implementation of BX2s regularisation using a consistent value for the horizontal field, instead of Athena's which is physically inconsistent.