### PR TITLE
use UGA's gitlab as LFS server to avoid github bandwidth limitations

### DIFF
--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       # Manually do a git LFS https://github.com/actions/checkout/issues/270
       - run: git lfs pull
@@ -91,7 +91,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: MHD Sod test
@@ -119,7 +119,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: Ambipolar C Shock
@@ -146,7 +146,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: Fargo + planet
@@ -165,7 +165,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: Hydro shearing box
@@ -184,7 +184,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: Jeans Instability
@@ -211,7 +211,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: 3 body
@@ -246,7 +246,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: Energy conservation
@@ -265,7 +265,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       # Manually do a git LFS https://github.com/actions/checkout/issues/270
       - run: git lfs pull
@@ -279,7 +279,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       - run: git lfs pull
       - name: Lookup table

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
       # Manually do a git LFS https://github.com/actions/checkout/issues/270
       - run: git lfs pull

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,2 @@
 [lfs]
-    url = https://gricad-gitlab.univ-grenoble-alpes.fr/discs/idefix-reference.git/info/lfs
+    url = https://gricad-gitlab.univ-grenoble-alpes.fr/lesurg/idefix-reference.git/info/lfs

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+    url = https://gricad-gitlab.univ-grenoble-alpes.fr/discs/idefix-reference.git/info/lfs


### PR DESCRIPTION
the large number of people cloning idefix will inevitably lead to problems with github's policy regarding LFS bandwidth. This MR fixes the issue by using UGA gitlab server to host LFS assets.