### PR TITLE
Improved debug and profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,11 @@ mpirun -np 8 ./idefix -dec 1 2 4 --kokkos-num-devices=4
 
 Profiling
 -------------------
-use the kokkos profiler tool, which can be downloaded from kokkos-tools (on github)
-Then set the environement variable:
+use the embedded profiling tool by adding "-profile" when calling idefix (no need to recompile)
 
 ```shell
-export KOKKOS_PROFILE_LIBRARY=kokkos-tools/src/tools/space-time-stack/kp_space_time_stack.so
-````
-
-and then simply run the code (no need to recompile)
+./idefix -profile
+```
 
 Debugging
 -------------------

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -58,7 +58,7 @@ Developement
 ------------
 
 I have a serious bug (e.g. segmentation fault), in my setup, how do I proceed?
-  Add ``-DIdefix_DEBUG=ON`` to ``cmake`` and recompile to find out exactly where the code crashes.
+  Add ``-DIdefix_DEBUG=ON`` to ``cmake`` and recompile to find out exactly where the code crashes (see :ref:`debugging`).
 
 I want to test a modification to *Idefix* source code specific to my problem without modifying files in `$IDEFIX_DIR`. How can I proceed?
   Add a ``CmakeLists.txt`` in your problem directory and use the function `replace_idefix_source` (see :ref:`customSourceFiles`).

--- a/doc/source/programmingguide.rst
+++ b/doc/source/programmingguide.rst
@@ -437,7 +437,7 @@ finished working with it. An example is provided in :ref:`setupInitDump`.
 .. _LookupTableClass:
 
 ``LookupTable`` class
------------------
+---------------------
 
 The ``LookupTable`` class allows one to read and interpolate elements from a coma-separated value (CSV) file or a numpy file
 (generated from ``numpy.save`` in python).
@@ -539,28 +539,33 @@ The ``Get`` and ``GetHost`` functions expect a C array of size ``nDim`` and retu
 .. note::
   Usage examples are provided in `test/utils/lookupTable`.
 
+
+.. _debugging:
+
 Debugging and profiling
 =======================
 
-The easiest way to trigger debugging in ``Idefix`` is to switch on ``Idefix_DEBUG`` in cmake (for instance
+The easiest way to trigger debugging in *Idefix* is to switch on ``Idefix_DEBUG`` in cmake (for instance
 adding ``-DIdefix_DEBUG=ON`` when calling cmake). This forces the code to log each time a function is called or
 returned (this is achieved thanks to the ``idfx::pushRegion(std::string)`` and ``idfx::popRegion()`` which are
-found at the beginning and end of each function). In addition, ``Idefix_DEBUG`` enables Kokkos array bound checks, which
-will throw an error each time one tries to access an array out of its allocated memory space. Note that all of these
+found at the beginning and end of each function). In addition, ``Idefix_DEBUG`` will force *Idefix* to wait for each
+``idefix_for`` to finish before continuing to the next instruction (otherwise, ``idefix_for`` are asynchronous when using
+an accelerator). This simplifies the detection and identification of bugs in ``idefix_for`` loops. Note that all of these
 debugging features induce a large overhead, and should therefore not be activated in production runs.
 
-It is also possible to use `Kokkos-tools <https://github.com/kokkos/kokkos-tools>`_ to debug and profile the code.
-For instance, on the fly profiling, can be enabled with the Kokkos ``space-time-stack`` tool. To use it, simply clone
-``Kokkos-tools`` to the directory of your choice, create a ``bin`` directory, configure the tools in the ``bin`` directory using
-cmake and compile it. It we assume that the path to the ``bin`` directory just created is ``<kokkos-tools-bin>`` then you can enable
-profiling by setting the environement variable ``KOKKOS_TOOLS_LIBS`` as:
+If you suspect an out-of-bound access, it may be worth enabling additionaly ``Kokkos_ENABLE_BOUNDS_CHECK`` that will check
+that you are not trying to access an array outside of its bounds.
+
+If you want to profile the code, the simplest way is to use the embedded profiling tool in *Idefix*, adding ``-profile`` to the command line
+when calling the code. This will produce a simplified profiling report when the *Idefix* finishes.
+
+It is also possible to use `Kokkos-tools <https://github.com/kokkos/kokkos-tools>`_ for more advanced profiling/debbugging. To use it,
+you must compile Kokkos tools in the directory of your choice and enable your favourite tool
+by setting the environement variable ``KOKKOS_TOOLS_LIBS`` to the tool path, for instance:
 
 .. code-block:: bash
 
   export KOKKOS_TOOLS_LIBS=<kokkos-tools-bin>/profiling/space-time-stack/libkp_space_time_stack.so
-
-Once this environement variable is set, *Idefix* automatically logs profiling informations when it ends (recompilation of *Idefix*
-is not needed).
 
 
 Minimal skeleton

--- a/doc/source/reference/commandline.rst
+++ b/doc/source/reference/commandline.rst
@@ -25,6 +25,8 @@ Several options can be provided at command line when running the code. These are
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -nowrite           |   disable all writes (useful for raw performance measures or for tests). This option implies ``-nolog``                 |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
+| -profile           |   Enable on-the-fly performance profiling (a final text report is automatically generated).                             |
++--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -Werror            |   warning messages are considered as errors and stop the code with a non-zero exit code.                                |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -62,7 +62,10 @@ int initialize() {
 
 void pushRegion(const std::string& kName) {
   Kokkos::Profiling::pushRegion(kName);
-
+  if(prof.perfEnabled) {
+    prof.currentRegion = prof.currentRegion->GetChild(kName);
+    prof.currentRegion->Start();
+  }
 #ifdef DEBUG
   regionIndent=regionIndent+4;
   for(int i=0; i < regionIndent ; i++) {
@@ -74,6 +77,10 @@ void pushRegion(const std::string& kName) {
 
 void popRegion() {
   Kokkos::Profiling::popRegion();
+  if(prof.perfEnabled) {
+    prof.currentRegion->Stop();
+    prof.currentRegion = prof.currentRegion->parent;
+  }
 #ifdef DEBUG
   for(int i=0; i < regionIndent ; i++) {
     cout << "-";

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -23,7 +23,7 @@ extern int prank;                       //< parallel rank
 extern int psize;
 extern IdefixOutStream cout;              //< custom cout for idefix
 extern IdefixErrStream cerr;              //< custom cerr for idefix
-extern Profiler prof;                   //< profiler (for memory usage)
+extern Profiler prof;                   //< profiler (for memory & performance usage)
 extern double mpiCallsTimer;            //< time significant MPI calls
 extern LoopPattern defaultLoopPattern;  //< default loop patterns (for idefix_for loops)
 extern bool warningsAreErrors;    //< whether warnings should be considered as errors

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -19,6 +19,7 @@
 #include "idefix.hpp"
 #include "input.hpp"
 #include "version.hpp"
+#include "profiler.hpp"
 
 // Flag will be set if a signal has been received
 bool Input::abortRequested = false;
@@ -171,6 +172,8 @@ void Input::ParseCommandLine(int argc, char **argv) {
       enableLogs = false;
     } else if(std::string(argv[i]) == "-nolog") {
       enableLogs = false;
+    } else if(std::string(argv[i]) == "-profile") {
+      idfx::prof.EnablePerformanceProfiling();
     } else if(std::string(argv[i]) == "-Werror") {
       idfx::warningsAreErrors = true;
     } else if(std::string(argv[i]) == "-version" || std::string(argv[i]) == "-v") {
@@ -399,6 +402,8 @@ void Input::PrintOptions() {
   idfx::cout << "         Do not generate any output file." << std::endl;
   idfx::cout << " -nolog" << std::endl;
   idfx::cout << "         Do not write any log file." << std::endl;
+  idfx::cout << " -profile" << std::endl;
+  idfx::cout << "         Enable on-the-fly performance profiling." << std::endl;
   idfx::cout << " -Werror" << std::endl;
   idfx::cout << "         Consider warnings as errors." << std::endl;
   idfx::cout << " -v/-version" << std::endl;

--- a/src/loop.hpp
+++ b/src/loop.hpp
@@ -66,6 +66,9 @@ template <typename Function>
 inline void idefix_for(const std::string & NAME,
                        const int & IB, const int & IE,
                        Function function) {
+  #ifdef DEBUG
+  idfx::pushRegion("idefix_for("+NAME+")");
+  #endif
   const int NI = IE - IB;
   Kokkos::parallel_for(NAME, NI,
     KOKKOS_LAMBDA (const int& IDX) {
@@ -73,6 +76,10 @@ inline void idefix_for(const std::string & NAME,
       i += IB;
       function(i);
   });
+  #ifdef DEBUG
+  Kokkos::fence();
+  idfx::popRegion();
+  #endif
 }
 
 
@@ -82,6 +89,9 @@ inline void idefix_for(const std::string & NAME,
                        const int & JB, const int & JE,
                        const int & IB, const int & IE,
                        Function function) {
+  #ifdef DEBUG
+  idfx::pushRegion("idefix_for("+NAME+")");
+  #endif
   // Kokkos 1D Range
   if constexpr(defaultLoop == LoopPattern::RANGE) {
     const int NJ = JE - JB;
@@ -123,6 +133,10 @@ inline void idefix_for(const std::string & NAME,
   } else {
     throw std::runtime_error("Unknown/undefined LoopPattern used.");
   }
+  #ifdef DEBUG
+  Kokkos::fence();
+  idfx::popRegion();
+  #endif
 }
 
 
@@ -133,6 +147,9 @@ inline void idefix_for(const std::string & NAME,
                        const int & JB, const int & JE,
                        const int & IB, const int & IE,
                        Function function) {
+  #ifdef DEBUG
+  idfx::pushRegion("idefix_for("+NAME+")");
+  #endif
   // Kokkos 1D Range
   if constexpr(defaultLoop == LoopPattern::RANGE) {
     const int NK = KE - KB;
@@ -201,6 +218,10 @@ inline void idefix_for(const std::string & NAME,
   } else {
     throw std::runtime_error("Unknown/undefined LoopPattern used.");
   }
+  #ifdef DEBUG
+  Kokkos::fence();
+  idfx::popRegion();
+  #endif
 }
 
 // 4D loop
@@ -211,6 +232,9 @@ inline void idefix_for(const std::string & NAME,
                        const int JB, const int JE,
                        const int IB, const int IE,
                        Function function) {
+  #ifdef DEBUG
+  idfx::pushRegion("idefix_for("+NAME+")");
+  #endif
   // Kokkos 1D Range
   if constexpr(defaultLoop == LoopPattern::RANGE) {
     const int NN = (NE) - (NB);
@@ -293,6 +317,10 @@ inline void idefix_for(const std::string & NAME,
   } else {
     throw std::runtime_error("Unknown/undefined LoopPattern used.");
   }
+  #ifdef DEBUG
+  Kokkos::fence();
+  idfx::popRegion();
+  #endif
 }
 
 #endif // LOOP_HPP_

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -6,6 +6,7 @@
 // ***********************************************************************************
 
 #include <algorithm>
+#include <iomanip>
 #include <mutex>    // NOLINT [build/c++11]
 #include <string>
 #include <vector>

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -5,12 +5,17 @@
 // Licensed under CeCILL 2.1 License, see COPYING for more information
 // ***********************************************************************************
 
+#include <algorithm>
 #include <mutex>    // NOLINT [build/c++11]
 #include <string>
+#include <vector>
+
 #include "idefix.hpp"
 #include "profiler.hpp"
 
-// Kokkos Profiler hooks
+/////////////////////////////
+// Kokkos Profiler hooks (needed to track memory allocation)
+/////////////////////////////
 
 extern "C" void kokkosp_allocate_data(const Kokkos_Profiling_SpaceHandle space,
   const char* label, const void* const ptr, const uint64_t size) {
@@ -47,7 +52,9 @@ const char* label, const void* const ptr, const uint64_t size) {
   idfx::prof.spaceSize[space_i] -= size;
 }
 
-
+///////////////////////////////////
+// Profiler function definitions //
+///////////////////////////////////
 void idfx::Profiler::Init() {
   idfx::pushRegion("Profiler::Init");
 
@@ -61,12 +68,13 @@ void idfx::Profiler::Init() {
   Kokkos::Tools::Experimental::set_allocate_data_callback(&kokkosp_allocate_data);
   Kokkos::Tools::Experimental::set_deallocate_data_callback(&kokkosp_deallocate_data);
 
+  // Init region
+
+
   idfx::popRegion();
 }
 
 void idfx::Profiler::Show() {
-  idfx::pushRegion("Profiler::Show");
-
   double usedMemory{-1};
 
   // follow ISO/IEC 80000
@@ -83,5 +91,112 @@ void idfx::Profiler::Show() {
     idfx::cout << "Profiler: maximum memory usage for " << this->spaceName[i];
     idfx::cout << " memory space: " << usedMemory << " " << units[count] << std::endl;
   }
-  idfx::popRegion();
+
+  if(perfEnabled) {
+    // Show performance results
+    rootRegion.Stop();
+    idfx::cout << "Profiler: performance results: " << std::endl;
+    idfx::cout << "-------------------------------------------------------------------------------";
+    idfx::cout << std::endl;
+    idfx::cout << "<total time>  <% of total time>  <% of self time>  <number of calls>  <name>";
+    idfx::cout << std::endl;
+    idfx::cout << "-------------------------------------------------------------------------------";
+    idfx::cout << std::endl;
+    rootRegion.Show(rootRegion.GetTimer());
+    idfx::cout << "-------------------------------------------------------------------------------";
+    idfx::cout << std::endl;
+    idfx::cout << "Profiler: end of performance profiling report." << std::endl;
+  }
+}
+
+void idfx::Profiler::EnablePerformanceProfiling() {
+  currentRegion = &rootRegion;
+  rootRegion.Start();
+  perfEnabled = true;
+}
+
+
+///////////////////////////////////
+// Region functions definitions //
+///////////////////////////////////
+
+
+idfx::Region::Region(Region *parent, std::string name, int level) {
+  this->parent = parent;
+  this->name = name;
+  this->level = level;
+}
+
+idfx::Region::Region() {
+  this->parent = nullptr;
+  this->name = std::string("Main");
+  this->level = 0;
+}
+
+idfx::Region::~Region() {
+  if(!isLeaf) {
+    // Delete all the children manually, since these are pointers
+    for( auto &it : children) {
+      delete it.second;
+    }
+  }
+}
+
+void idfx::Region::Start() {
+  this->nCalls++;
+  this->timer.reset();
+}
+
+double idfx::Region::GetTimer() {
+  return this->myTime;
+}
+
+void idfx::Region::Stop() {
+  this->myTime += this->timer.seconds();
+}
+
+idfx::Region * idfx::Region::GetChild(std::string name) {
+  isLeaf=false;
+  if(this->children.find(name) == this->children.end()) {
+    // No children found
+    this->children[name] = new Region(this, name, this->level+1);
+  }
+  return this->children[name];
+}
+
+bool idfx::Region::Compare(Region * r1, Region * r2) {
+  return r1->GetTimer() > r2->GetTimer();
+}
+
+void idfx::Region::Show(double totTime) {
+  // Compute time of all the children
+  double childTime = 0;
+
+  if(!isLeaf) {
+    for( auto &it : children) {
+          childTime += it.second->GetTimer();
+        }
+  }
+  for(int i = 0 ; i < (this->level) ; i++) {
+    idfx::cout << "|   ";
+  }
+
+  idfx::cout << "|-> " << std::scientific << std::setprecision(2) << this->myTime << " sec  "
+             << std::fixed << std::setprecision(1)
+             << this->myTime/totTime*100 << "%  "
+             << (this->myTime-childTime)/this->myTime*100 << "%  "
+             << this->nCalls << "  "
+             << this->name << std::endl;
+  if(!isLeaf) {
+    // Sort the children
+    std::vector<Region*> sorted;
+    for( auto &it : this->children) {
+      sorted.push_back(it.second);
+    }
+
+    std::sort(sorted.begin(), sorted.end(), this->Compare);
+    for( auto &it : sorted) {
+          it->Show(totTime);
+        }
+  }
 }

--- a/src/profiler.hpp
+++ b/src/profiler.hpp
@@ -8,7 +8,9 @@
 #ifndef PROFILER_HPP_
 #define PROFILER_HPP_
 
+#include <map>
 #include <mutex>  // NOLINT [build/c++11]
+#include <string>
 
 namespace idfx {
 
@@ -16,16 +18,49 @@ struct SpaceHandle {
   char name[64];
 };
 
+// Region is a helper class to Profiler
+// it used to generate a tree of the regions encountered while running
+// and produce a performance report.
+class Region {
+ public:
+  Region(Region *parent, std::string name, int level);
+  Region();
+  ~Region();
+  void Start();
+  void Stop();
+  void Show(double );
+  Region* GetChild(std::string name);
+  double GetTimer();
+  static bool Compare(Region *, Region *);
+  bool isLeaf{true};
+  std::string name;
+  std::map<std::string, Region*> children;
+  Region *parent;
+  int level;
+ private:
+  Kokkos::Timer timer;
+  double myTime{0};
+  int64_t nCalls{0};
+};
+
+
 class Profiler {
  public:
   void Init();
   void Show();
+  void EnablePerformanceProfiling();
   int numSpaces;
   int64_t spaceSize[16];
   int64_t spaceMax[16];
   char spaceName[16][64];
   std::mutex m;
+
+  bool perfEnabled{false};
+  Region rootRegion;
+  Region *currentRegion;
 };
+
+
 
 }// namespace idfx
 

--- a/src/reduce.hpp
+++ b/src/reduce.hpp
@@ -23,8 +23,15 @@ inline void idefix_reduce(const std::string & NAME,
                 const int & IB, const int & IE,
                 Function function,
                 Reducer redFunction) {
+    #ifdef DEBUG
+    idfx::pushRegion("idefix_reduce("+NAME+")");
+    #endif
     Kokkos::parallel_reduce(NAME,
       Kokkos::RangePolicy<>(IB,IE), function, redFunction);
+    #ifdef DEBUG
+    Kokkos::fence();
+    idfx::popRegion();
+    #endif
 }
 
 // 2D default loop pattern
@@ -34,11 +41,20 @@ inline void idefix_reduce(const std::string & NAME,
                 const int & IB, const int & IE,
                 Function function,
                 Reducer redFunction) {
+    #ifdef DEBUG
+    idfx::pushRegion("idefix_reduce("+NAME+")");
+    #endif
+
     // We only implement MDRange reductions here since the other implementations are too
     // complicated to be implemented for any reduction operator on any class
     Kokkos::parallel_reduce(NAME,
       Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Right, Kokkos::Iterate::Right>>
         ({JB,IB},{JE,IE}), function, redFunction);
+
+    #ifdef DEBUG
+    Kokkos::fence();
+    idfx::popRegion();
+    #endif
 }
 
 // 3D default loop pattern
@@ -51,9 +67,17 @@ inline void idefix_reduce(const std::string & NAME,
                 Reducer redFunction) {
     // We only implement MDRange reductions here since the other implementations are too
     // complicated to be implemented for any reduction operator on any class
+    #ifdef DEBUG
+    idfx::pushRegion("idefix_reduce("+NAME+")");
+    #endif
     Kokkos::parallel_reduce(NAME,
       Kokkos::MDRangePolicy<Kokkos::Rank<3, Kokkos::Iterate::Right, Kokkos::Iterate::Right>>
         ({KB,JB,IB},{KE,JE,IE}), function, redFunction);
+
+    #ifdef DEBUG
+    Kokkos::fence();
+    idfx::popRegion();
+    #endif
 }
 
 // 4D default loop pattern
@@ -67,9 +91,17 @@ inline void idefix_reduce(const std::string & NAME,
                 Reducer redFunction) {
     // We only implement MDRange reductions here since the other implementations are too
     // complicated to be implemented for any reduction operator on any class
+    #ifdef DEBUG
+    idfx::pushRegion("idefix_reduce("+NAME+")");
+    #endif
     Kokkos::parallel_reduce(NAME,
       Kokkos::MDRangePolicy<Kokkos::Rank<4, Kokkos::Iterate::Right, Kokkos::Iterate::Right>>
         ({NB,KB,JB,IB},{NE,KE,JE,IE}), function, redFunction);
+
+    #ifdef DEBUG
+    Kokkos::fence();
+    idfx::popRegion();
+    #endif
 }
 
 #endif // REDUCE_HPP_


### PR DESCRIPTION
This PR proposes improvements in the debugging/profiling function provided by Idefix:
- when DEBUG is enabled, force Idefix to wait for the execution of idefix_for loops (avoid asynchronous errors that are always cumbersome). Additionally, print out the executions of idefix_for, so that the user knows when these loops are executed.
- add a new `-profile` option that generate automatically a profiling report without requiring Kokkos-tools.
- fix the documentation accordingly (in particular, fix #182 )