### PR TITLE
ENH: add CLI flag to force calling Setup::InitFlow ahead of dump reading at restart

### DIFF
--- a/doc/source/reference/commandline.rst
+++ b/doc/source/reference/commandline.rst
@@ -21,6 +21,8 @@ Several options can be provided at command line when running the code. These are
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -maxcycles n       |   stops when the code has performed ``n`` integration cycles                                                            |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
+| -force_init        |   call initial conditions before reading dump file  (this has no effect if -restart is not also passed)                 |
++--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -nolog             |   disable log files                                                                                                     |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -nowrite           |   disable all writes (useful for raw performance measures or for tests). This option implies ``-nolog``                 |

--- a/doc/source/reference/commandline.rst
+++ b/doc/source/reference/commandline.rst
@@ -21,7 +21,9 @@ Several options can be provided at command line when running the code. These are
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -maxcycles n       |   stops when the code has performed ``n`` integration cycles                                                            |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
-| -force_init        |   call initial conditions before reading dump file  (this has no effect if -restart is not also passed)                 |
+| -force_init        | |  call initial conditions before reading dump file  (this has no effect if -restart is not also passed).               |
+|                    | |  This option is useful when more physics is enabled when restarting from a dump (e.g. switching on MHD or dust)       |
+|                    | |  as it initialize from the initial conditions the quantities that are absent from the restart dump                    |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+
 | -nolog             |   disable log files                                                                                                     |
 +--------------------+-------------------------------------------------------------------------------------------------------------------------+

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -167,6 +167,8 @@ void Input::ParseCommandLine(int argc, char **argv) {
       }
       this->maxCycles = std::stoi(std::string(argv[++i]));
       inputParameters["CommandLine"]["maxCycles"].push_back(std::to_string(maxCycles));
+    } else if(std::string(argv[i]) == "-force_init") {
+      this->forceInitRequested = true;
     } else if(std::string(argv[i]) == "-nowrite") {
       this->forceNoWrite = true;
       enableLogs = false;
@@ -398,6 +400,9 @@ void Input::PrintOptions() {
   idfx::cout << "         Use the input file xxx instead of the default idefix.ini" << std::endl;
   idfx::cout << " -maxcycles n" << std::endl;
   idfx::cout << "         Perform at most n integration cycles." << std::endl;
+  idfx::cout << " -force_init" << std::endl;
+  idfx::cout << "         Call initial conditions before reading dump file ";
+  idfx::cout << "(this has no effect if -restart is not also passed)" << std::endl;
   idfx::cout << " -nowrite" << std::endl;
   idfx::cout << "         Do not generate any output file." << std::endl;
   idfx::cout << " -nolog" << std::endl;

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -57,6 +57,7 @@ class Input {
 
   bool restartRequested{false};       //< Should we restart?
   int  restartFileNumber;             //< if yes, from which file?
+  bool forceInitRequested{false};     // call DataBlock::InitFlow even on restarts ?
 
   static bool abortRequested;         //< Did we receive an abort signal (USR2) from the system?
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,12 @@ int main( int argc, char* argv[] ) {
     ///////////////////////////////
     // Are we restarting?
     if(input.restartRequested) {
+      if(input.forceInitRequested) {
+        idfx::pushRegion("Setup::Initflow");
+        mysetup.InitFlow(data);
+        data.DeriveVectorPotential();
+        idfx::popRegion();
+      }
       idfx::cout << "Main: Restarting from dump file."  << std::endl;
       bool restartSuccess = output.RestartFromDump(data,input.restartFileNumber);
       if(!restartSuccess) {


### PR DESCRIPTION
As discussed earlier this week with @glesur, add a way to force initial conditions *ahead* of dump reading on restart. This allows users to add new datastructures on restart (like particles, multi-fluids ...).


TODO:
- [x] validate that this is a sound approach for particles (this will be done externally, on my private fork)
- [x] agree on the exact name of the flag
- [ ] discuss the limits of this implementation and wether this is actually needed or not in all the cases we mean to support
- [x] add documentation for it
