### PR TITLE
Improved self gravity

### DIFF
--- a/src/gravity/CMakeLists.txt
+++ b/src/gravity/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(idefix
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/gravity.hpp
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/gravity.cpp
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/laplacian.cpp
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/laplacian.hpp
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/selfGravity.hpp
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/selfGravity.cpp
   )

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -380,7 +380,7 @@ void Laplacian::PreComputeLaplacian() {
       // i-1 coefficient
       Lx1(0,k,j,i) = 2.0 * Ax1(k, j, i) / h1 / (dx1(i) + dx1(i-1)) / dV(k,j,i);
       // i+1 coefficient
-      Lx1(1,k,j,i) = 2.0 * Ax1(k, j, i+1) / h1 / (dx1(i+1) + dx1(1)) / dV(k,j,i);
+      Lx1(1,k,j,i) = 2.0 * Ax1(k, j, i+1) / h1 / (dx1(i+1) + dx1(i)) / dV(k,j,i);
       if(havePreconditioner) {
         Lx1(0,k,j,i) /= P(k,j,i);
         Lx1(1,k,j,i) /= P(k,j,i);

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -400,7 +400,7 @@ void SelfGravity::PreComputeLaplacian() {
 }
 
 
-void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real> laplacian) {
+void SelfGravity::operator()(IdefixArray3D<real> array, IdefixArray3D<real> laplacian) {
   idfx::pushRegion("SelfGravity::ComputeLaplacian");
 
   int ibeg, iend, jbeg, jend, kbeg, kend;
@@ -451,7 +451,7 @@ void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real
   idfx::popRegion();
 }
 
-void Laplacian::EnforceBoundary(int dir, BoundarySide side, GravityBoundaryType type,
+void Laplacian::EnforceBoundary(int dir, BoundarySide side, LaplacianBoundaryType type,
                                   IdefixArray3D<real> &arr) {
   idfx::pushRegion("SelfGravity::EnforceBoundary");
 

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -353,7 +353,7 @@ void Laplacian::PreComputeLaplacian() {
                         JOFFSET,this->np_tot[JDIR]-JOFFSET,
                         IOFFSET,this->np_tot[IDIR]-JOFFSET,
     KOKKOS_LAMBDA(int k, int j,int i) {
-      real h1, h2, h3;
+      [[maybe_unused]] real h1, h2, h3;
       #if GEOMETRY == CARTESIAN
       h1 = 1.;
       h2 = 1.;

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -1,0 +1,650 @@
+// ***********************************************************************************
+// Idefix MHD astrophysical code
+// Copyright(C) Geoffroy R. J. Lesur <geoffroy.lesur@univ-grenoble-alpes.fr>
+// and other code contributors
+// Licensed under CeCILL 2.1 License, see COPYING for more information
+// ***********************************************************************************
+
+
+
+#include <string>
+#include <vector>
+#include "laplacian.hpp"
+#include "selfGravity.hpp"
+#include "dataBlock.hpp"
+
+
+Laplacian::Laplacian(DataBlock &datain, std::array<LaplacianBoundaryType,3> leftBound, 
+                                        std::array<LaplacianBoundaryType,3> rightBound,
+                                        bool havePreconditionnerIn) {
+  // Save the parents data objects
+  this->data = &datain;
+  this->havePreconditioner = havePreconditionnerIn;
+
+  // init the grid elements using the parent datablock
+  this->np_tot = data->np_tot;
+  this->np_int = data->np_int;
+  this->nghost = data->nghost;
+  this->beg = data->beg;
+  this->end = data->end;
+  this->x = data->x;
+  this->dx = data->dx;
+  this->sinx2 = data->sinx2;
+  this->dV = data->dV;
+  this->A = data->A;
+  this->loffset = std::vector<int>(3,0);
+  this->roffset = std::vector<int>(3,0);
+
+  this->lbound = leftBound;
+  this->rBound = rightBound;
+
+  isPeriodic = true;
+  for(int dir = 0 ; dir < 3 ; dir++) {
+    if(lbound[dir] != LaplacianBoundaryType::periodic && 
+       lbound[dir] != LaplacianBoundaryType::internalgrav) isPeriodic = false;
+    if(rbound[dir] != LaplacianBoundaryType::periodic &&
+       rbound[dir] != LaplacianBoundaryType::internalgrav) isPeriodic = false;
+  }
+
+  #if GEOMETRY == SPHERICAL
+    if ((this->rbound[JDIR]==axis) || (this->lbound[JDIR]==axis)) {
+      // Check wether the x3 spherical axis is full two pi
+      if(fabs((data->mygrid->xend[KDIR] - data->mygrid->xbeg[KDIR] -2.0*M_PI)) < 1e-10) {
+        this->isTwoPi = true;
+      }
+
+    #ifdef WITH_MPI
+      // Check that there is no domain decomposition in phi
+      if(data->mygrid->nproc[KDIR]>1) {
+        IDEFIX_ERROR("SelfGravity:: Axis boundaries are not compatible with "
+                     "MPI domain decomposition in X3");
+      }
+    #endif
+    }
+  #endif
+
+  // Init MPI stack when needed
+  #ifdef WITH_MPI
+  this->arr4D = IdefixArray4D<real> ("WorkingArrayMpi", 1, this->np_tot[KDIR],
+                                                           this->np_tot[JDIR],
+                                                           this->np_tot[IDIR]);
+
+  int ntarget = 0;
+  std::vector<int> mapVars;
+  mapVars.push_back(ntarget);
+
+  this->mpi.Init(data->mygrid, mapVars, this->nghost.data(), this->np_int.data());
+  #endif
+
+
+  if(this->lbound[IDIR] == origin) {
+    InitInternalGrid();
+  }
+
+  // Init preconditionner if needed
+  if(havePreconditioner) {
+    InitPreconditionner();
+  }
+  // Initialise the Laplacian coefficients
+  PreComputeLaplacian();
+
+
+}
+
+void Laplacian::InitInternalGrid() {
+  idfx::pushRegion("SelfGravity::InitInternalGrid");
+  // Extend the grid so that the inner radius will be 1/10 of the initial inner radius
+  GridHost gh(*data->mygrid);
+  gh.SyncFromDevice();
+
+  real dx0 = gh.dx[IDIR](0);
+  real rin = gh.xbeg[IDIR]/10.0;
+
+  loffset[IDIR] = (gh.xl[IDIR](0) - rin) / dx0;
+
+  this->np_tot[IDIR] += loffset[IDIR];
+  this->np_int[IDIR] += loffset[IDIR];
+  this->end[IDIR] += loffset[IDIR];
+
+  // Allocate required arrays
+  this->x[IDIR] = IdefixArray1D<real>("SG_x1", this->np_tot[IDIR]);
+  this->dx[IDIR] = IdefixArray1D<real>("SG_dx1", this->np_tot[IDIR]);
+  this->dV = IdefixArray3D<real>("SG_dV", this->np_tot[KDIR],
+                                          this->np_tot[JDIR],
+                                          this->np_tot[IDIR]);
+  for(int dir = 0 ; dir < 3 ; dir ++) {
+    this->A[dir] = IdefixArray3D<real>("SG_A", this->np_tot[KDIR]+KOFFSET,
+                                          this->np_tot[JDIR]+JOFFSET,
+                                          this->np_tot[IDIR]+IOFFSET);
+  }
+  // xl and xr are used only temporarily in this subroutine.
+  auto x1l = IdefixArray1D<real>("SG_x1l", this->np_tot[IDIR]);
+  auto x1r = IdefixArray1D<real>("SG_x1r", this->np_tot[IDIR]);
+  // incidentally, sinx2 is not affected by a grid extension in x1, so no need to
+  // allocate a new array
+
+
+  // Fill selfgravity with the existing datablock grid
+  int ioffset = loffset[IDIR];
+
+  auto x1in = data->x[IDIR];
+  auto x1lin = data->xl[IDIR];
+  auto x1rin = data->xr[IDIR];
+  auto dx1in = data->dx[IDIR];
+  auto x1 = this->x[IDIR];
+  auto dx1 = this->dx[IDIR];
+  idefix_for("InternalGridCopy",0, data->np_tot[IDIR],
+     KOKKOS_LAMBDA(int i) {
+       x1(i+ioffset) = x1in(i);
+       dx1(i+ioffset) = dx1in(i);
+       x1l(i+ioffset) = x1lin(i);
+       x1r(i+ioffset) = x1rin(i);
+     });
+
+  // extend with a uniform grid and spacing equal to first of the datablock
+  idefix_for("InternalGridFill",0, ioffset,
+     KOKKOS_LAMBDA(int i) {
+       const real dx0 = dx1(ioffset);
+       dx1(i) = dx0;
+       x1(i) = x1(ioffset) + (i-ioffset)*dx0;
+       x1l(i) = x1l(ioffset) + (i-ioffset)*dx0;
+       x1r(i) = x1l(ioffset) + (i-ioffset+1)*dx0;
+     });
+
+  // Check that all is well
+  IdefixArray1D<real>::HostMirror xH = Kokkos::create_mirror_view(x1l);
+  Kokkos::deep_copy(xH, x1l);
+
+  if(xH(0)<0.0) {
+    IDEFIX_ERROR("SelfGravity: Your grid extension goes beyond the origin!");
+  }
+
+  IdefixArray3D<real> dV  = this->dV;
+  //IdefixArray1D<real> dx1 = this->dx[IDIR];
+  IdefixArray1D<real> dx2 = this->dx[JDIR];
+  IdefixArray1D<real> dx3 = this->dx[KDIR];
+  //IdefixArray1D<real> x1  = this->x[IDIR];
+  IdefixArray1D<real> x2  = this->x[JDIR];
+  IdefixArray1D<real> x3  = this->x[KDIR];
+  IdefixArray1D<real> x1p = x1r;
+  IdefixArray1D<real> x2p = data->xr[JDIR];
+  IdefixArray1D<real> x3p = data->xr[KDIR];
+  IdefixArray1D<real> x1m = x1l;
+  IdefixArray1D<real> x2m = data->xl[JDIR];
+  IdefixArray1D<real> x3m = data->xl[KDIR];
+
+  // Fill the volume and area arrays (assume spherical geometry)
+  idefix_for("Volumes",0,this->np_tot[KDIR],0,this->np_tot[JDIR],0,this->np_tot[IDIR],
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      real dVr = FABS(x1p(i)*x1p(i)*x1p(i) - x1m(i)*x1m(i)*x1m(i))/3.0;
+      real dmu = FABS(cos(x2m(j)) - cos(x2p(j)));
+      dV(k,j,i) = D_EXPAND( dVr, *dmu, *dx3(k));
+    }
+  );
+
+  // Compute Areas
+  IdefixArray3D<real> Ax1 = this->A[IDIR];
+  IdefixArray3D<real> Ax2 = this->A[JDIR];
+  IdefixArray3D<real> Ax3 = this->A[KDIR];
+
+  // X1 direction
+  int end = this->np_tot[IDIR];
+  idefix_for("AreaX1",0,this->np_tot[KDIR],0,this->np_tot[JDIR],0,this->np_tot[IDIR]+IOFFSET,
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      real dmu = FABS(cos(x2m(j)) - cos(x2p(j)));
+      if(i == end) {
+        Ax1(k,j,i) = D_EXPAND(x1p(i-1)*x1p(i-1), *dmu, *dx3(k));
+      } else {
+        Ax1(k,j,i) = D_EXPAND(x1m(i)*x1m(i), *dmu, *dx3(k)); // r^2*dmu*dphi
+      }
+    });
+
+  // X2 direction
+  end = this->np_tot[JDIR];
+  idefix_for("AreaX2",0,this->np_tot[KDIR],0,this->np_tot[JDIR]+JOFFSET,0,this->np_tot[IDIR],
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      if (j == end) {
+        Ax2(k,j,i) = D_EXPAND(x1(i)*dx1(i), *FABS(sin(x2p(j-1))), *dx3(k));
+      } else {
+        Ax2(k,j,i) = D_EXPAND(x1(i)*dx1(i), *FABS(sin(x2m(j))), *dx3(k)); // = r*dr*sin(thp)*dphi
+      }
+    });
+
+  // X3 direction
+  end = this->np_tot[KDIR];
+  idefix_for("AreaX3",0,this->np_tot[KDIR]+KOFFSET,0,this->np_tot[JDIR],0,this->np_tot[IDIR],
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      Ax3(k,j,i) = D_EXPAND(x1(i)*dx1(i), *dx2(j), *ONE_F);   // = r*dr*dth
+    }
+  );
+
+  idfx::popRegion();
+}
+
+void Laplacian::InitPreconditionner() {
+  idfx::pushRegion("SelfGravity::InitPreconditioner");
+  IdefixArray3D<real> P = IdefixArray3D<real> ("Preconditionner", this->np_tot[KDIR],
+                                                                  this->np_tot[JDIR],
+                                                                  this->np_tot[IDIR]);
+
+  int ibeg, iend, jbeg, jend, kbeg, kend;
+  ibeg = this->beg[IDIR];
+  iend = this->end[IDIR];
+  jbeg = this->beg[JDIR];
+  jend = this->end[JDIR];
+  kbeg = this->beg[KDIR];
+  kend = this->end[KDIR];
+
+  // Set array to zero
+  idefix_for("ResetPrecond", kbeg, kend, jbeg, jend, ibeg, iend,
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      P(k,j,i) = 0;
+    });
+
+  IdefixArray3D<real> dV = this->dV;
+
+  #if (GEOMETRY==CYLINDRICAL) || (GEOMETRY==POLAR)
+  IdefixArray1D<real> r = this->x[IDIR];
+  #elif GEOMETRY==SPHERICAL
+  IdefixArray1D<real> r = this->x[IDIR];
+  IdefixArray1D<real> sinth = this->sinx2;
+  #endif
+
+  // Loop on dimensions to get the diagonal elements
+  for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
+    IdefixArray1D<real> dx = this->dx[dir];
+    IdefixArray3D<real> Ax = this->A[dir];
+    int ioffset = (dir == IDIR) ? 1 : 0;
+    int joffset = (dir == JDIR) ? 1 : 0;
+    int koffset = (dir == KDIR) ? 1 : 0;
+
+    idefix_for("InitPrecond", kbeg, kend, jbeg, jend, ibeg, iend,
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      int index = i*ioffset + j*joffset + k*koffset;
+      real dx0 = dx(index);
+      real dxm = dx(index-1);
+      real dxp = dx(index+1);
+
+      real Ap = Ax(k+koffset, j+joffset, i+ioffset);
+      real Am = Ax(k,j,i);
+
+      // Compute the diagonal elements coming from the laplacian
+      real d = -(2.0*Ap/(dx0+dxp) + 2.0*Am/(dx0+dxm)) / dV(k,j,i);
+
+      // Handling curvature terms
+      real h1, h2, h3;
+      #if GEOMETRY==CARTESIAN
+      h1=1.;
+      h2=1.;
+      h3=1.;
+      #elif GEOMETRY==CYLINDRICAL
+      h1=1.;
+      h2=1.;
+      h3=r(i); // Should never be used (cf. Idefix docu)
+      #elif GEOMETRY==POLAR
+      h1=1.;
+      h2=r(i);
+      h3=1.;
+      #else
+      h1=1.;
+      h2=r(i);
+      h3=r(i)*sinth(j);
+      #endif
+
+      // Full diagonal element (including curvature terms)
+      d = d/(h1*ioffset+h2*joffset+h3*koffset);
+
+      // We store in P the sum of all these elements
+      P(k,j,i) += d;
+    });
+  }
+
+  // Store the array for future use
+  this->precond = P;
+
+  idfx::popRegion();
+}
+
+void SelfGravity::PreComputeLaplacian() {
+  idfx::pushRegion("SelfGravity::PreComputeLaplacian");
+   // Precompute Laplacian Factor
+
+  // Allocate Laplacian factors
+  this->Lx1 = IdefixArray4D<real>("SelfGravity_Lx1",2, 
+                                                    this->np_tot[KDIR], 
+                                                    this->np_tot[JDIR],
+                                                    this->np_tot[IDIR]);
+  #if DIMENSIONS > 1
+    this->Lx2 = IdefixArray4D<real>("SelfGravity_Lx2",2, 
+                                                      this->np_tot[KDIR], 
+                                                      this->np_tot[JDIR],
+                                                      this->np_tot[IDIR]);
+
+    #if DIMENSIONS > 2
+      this->Lx3 = IdefixArray4D<real>("SelfGravity_Lx3",2, 
+                                                        this->np_tot[KDIR], 
+                                                        this->np_tot[JDIR],
+                                                        this->np_tot[IDIR]);
+    #endif
+  #endif
+
+
+  // Local copy of Laplacian arrays
+  IdefixArray4D<real> Lx1 = this->Lx1; // X stride
+  IdefixArray4D<real> Lx2 = this->Lx2; // Y stride
+  IdefixArray4D<real> Lx3 = this->Lx3; // Z stride
+
+
+  IdefixArray3D<real> P = this->precond;
+  bool havePreconditioner = this->havePreconditioner;
+  IdefixArray1D<real> dx1 = this->dx[IDIR];
+  IdefixArray1D<real> dx2 = this->dx[JDIR];
+  IdefixArray1D<real> dx3 = this->dx[KDIR];
+  IdefixArray3D<real> Ax1 = this->A[IDIR];
+  IdefixArray3D<real> Ax2 = this->A[JDIR];
+  IdefixArray3D<real> Ax3 = this->A[KDIR];
+  IdefixArray3D<real> dV = this->dV;
+  #if GEOMETRY == POLAR
+  IdefixArray1D<real> r = this->x[IDIR];
+  #elif GEOMETRY == SPHERICAL
+  IdefixArray1D<real> r = this->x[IDIR];
+  IdefixArray1D<real> sinth = this->sinx2;
+  #endif
+
+  idefix_for("L_Factor",KOFFSET,this->np_tot[KDIR]-KOFFSET,
+                        JOFFSET,this->np_tot[JDIR]-JOFFSET,
+                        IOFFSET,this->np_tot[IDIR]-JOFFSET,
+    KOKKOS_LAMBDA(int k, int j,int i) {
+      real h1, h2, h3;
+      #if GEOMETRY == CARTESIAN
+      h1 = 1.;
+      h2 = 1.;
+      h3 = 1.;
+      #elif GEOMETRY == POLAR
+      h1 = 1.;
+      h2 = r(i);
+      h3 = 1.;
+      #else
+      h1 = 1.;
+      h2 = r(i);
+      h3 = r(i) * sinth(j);
+      #endif
+
+      // i-1 coefficient
+      Lx1(0,k,j,i) = 2.0 * Ax1(k, j, i) / h1 / (dx1(i) + dx1(i-1)) / dV(k,j,i);
+      // i+1 coefficient
+      Lx1(1,k,j,i) = 2.0 * Ax1(k, j, i+1) / h1 / (dx1(i+1) + dx1(1)) / dV(k,j,i);
+      if(havePreconditioner) {
+        Lx1(0,k,j,i) /= P(k,j,i);
+        Lx1(1,k,j,i) /= P(k,j,i);
+      }
+      #if DIMENSIONS > 1
+        Lx2(0,k,j,i) = 2.0 * Ax2(k, j, i) / h2 / (dx2(j) + dx2(j-1)) / dV(k,j,i);
+        Lx2(1,k,j,i) = 2.0 * Ax2(k, j+1, i) / h2 / (dx2(j+1) + dx2(j)) / dV(k,j,i);
+        if(havePreconditioner) {
+          Lx2(0,k,j,i) /= P(k,j,i);
+          Lx2(1,k,j,i) /= P(k,j,i);
+        }
+        #if DIMENSIONS > 2
+          Lx3(0,k,j,i) = 2.0 * Ax3(k, j, i) / h3 / (dx3(k) + dx3(k-1)) / dV(k,j,i);
+          Lx3(1,k,j,i) = 2.0 * Ax3(k+1, j, i) / h3 / (dx3(k+1) + dx3(k)) / dV(k,j,i);
+          if(havePreconditioner) {
+            Lx3(0,k,j,i) /= P(k,j,i);
+            Lx3(1,k,j,i) /= P(k,j,i);
+          }
+        #endif
+      #endif
+      
+    });
+  idfx::popRegion();
+}
+
+
+void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real> laplacian) {
+  idfx::pushRegion("SelfGravity::ComputeLaplacian");
+
+  int ibeg, iend, jbeg, jend, kbeg, kend;
+  ibeg = this->beg[IDIR];
+  iend = this->end[IDIR];
+  jbeg = this->beg[JDIR];
+  jend = this->end[JDIR];
+  kbeg = this->beg[KDIR];
+  kend = this->end[KDIR];
+  IdefixArray4D<real> Lx1 = this->Lx1;
+  #if DIMENSIONS > 1
+    IdefixArray4D<real> Lx2 = this->Lx2;
+    #if DIMENSIONS > 2
+      IdefixArray4D<real> Lx3 = this->Lx3;
+    #endif
+  #endif
+
+  // Handling boundaries before laplacian calculation
+  this->SetBoundaries(array);
+
+  idefix_for("FiniteDifference", kbeg, kend, jbeg, jend, ibeg, iend,
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      real gc = 0;
+      real Delta = 0;
+      real Lm, Lr;
+      #if DIMENSIONS > 2
+      Lm = Lx3(0,k,j,i);
+      Lr = Lx3(1,k,j,i);
+      gc += Lm + Lr;
+      Delta += array(k-1,j,i)*Lm + array(k+1,j,i)*Lr;
+      #endif
+      #if DIMENSIONS > 1
+        Lm = Lx2(0,k,j,i);
+        Lr = Lx2(1,k,j,i);
+        gc += Lm + Lr;
+        Delta += array(k,j-1,i)*Lm + array(k,j+1,i)*Lr;
+      #endif
+      Lm = Lx1(0,k,j,i);
+      Lr = Lx1(1,k,j,i);
+      gc += Lm + Lr;
+      Delta += array(k,j,i-1)*Lm + array(k,j,i+1)*Lr;
+
+      Delta -= gc * array(k,j,i);
+
+      laplacian(k, j, i) = Delta;
+    });
+
+  idfx::popRegion();
+}
+
+void Laplacian::EnforceBoundary(int dir, BoundarySide side, GravityBoundaryType type,
+                                  IdefixArray3D<real> &arr) {
+  idfx::pushRegion("SelfGravity::EnforceBoundary");
+
+  IdefixArray3D<real> localVar = arr;
+
+  // Number of active cells
+  const int nxi = this->np_int[IDIR];
+  const int nxj = this->np_int[JDIR];
+  const int nxk = this->np_int[KDIR];
+
+  // Number of ghost cells
+  const int ighost = this->nghost[IDIR];
+  const int jghost = this->nghost[JDIR];
+  const int kghost = this->nghost[KDIR];
+
+  // Boundaries of the loop
+  const int ibeg = (dir == IDIR) ? side*(ighost+nxi) : 0;
+  const int iend = (dir == IDIR) ? ighost + side*(ighost+nxi) : this->np_tot[IDIR];
+  const int jbeg = (dir == JDIR) ? side*(jghost+nxj) : 0;
+  const int jend = (dir == JDIR) ? jghost + side*(jghost+nxj) : this->np_tot[JDIR];
+  const int kbeg = (dir == KDIR) ? side*(kghost+nxk) : 0;
+  const int kend = (dir == KDIR) ? kghost + side*(kghost+nxk) : this->np_tot[KDIR];
+
+  switch(type) {
+    case internalgrav:
+      // internal is used for MPI-enforced boundary conditions. Nothing to be done here.
+      break;
+
+    case periodic: {
+      if(data->mygrid->nproc[dir] > 1) break; // Periodicity already enforced by MPI calls
+
+      idefix_for("BoundaryPeriodic", kbeg, kend, jbeg, jend, ibeg, iend,
+            KOKKOS_LAMBDA (int k, int j, int i) {
+              int iref, jref, kref;
+              // This hack takes care of cases where we have more ghost zones than active zones
+              if(dir==IDIR)
+                iref = ighost + (i+ighost*(nxi-1))%nxi;
+              else
+                iref = i;
+              if(dir==JDIR)
+                jref = jghost + (j+jghost*(nxj-1))%nxj;
+              else
+                jref = j;
+              if(dir==KDIR)
+                kref = kghost + (k+kghost*(nxk-1))%nxk;
+              else
+                kref = k;
+
+              localVar(k,j,i) = localVar(kref,jref,iref);
+      });
+      break;
+    }
+
+    case userdef: {
+      if(this->haveUserDefBoundary) {
+        // Warning: unlike hydro userdef boundary functions, the selfGravity
+        // userdef boundary functions take an additional argument arr which
+        // specifies the array for which boundaries are to be handled
+        this->userDefBoundaryFunc(*data, dir, side, data->t, arr);
+      } else {
+        IDEFIX_ERROR("SelfGravity:: No function enrolled to define your own boundary conditions");
+      }
+      break;
+    }
+
+    case nullpot: {
+      idefix_for("BoundaryNullPot", kbeg, kend, jbeg, jend, ibeg, iend,
+            KOKKOS_LAMBDA (int k, int j, int i) {
+              localVar(k,j,i) = 0.0;
+      });
+      break;
+    }
+
+    case nullgrad: {
+      idefix_for("BoundaryNullGrad", kbeg, kend, jbeg, jend, ibeg, iend,
+            KOKKOS_LAMBDA (int k, int j, int i) {
+              const int iref = (dir==IDIR) ? ighost + side*(nxi-1) : i;
+              const int jref = (dir==JDIR) ? jghost + side*(nxj-1) : j;
+              const int kref = (dir==KDIR) ? kghost + side*(nxk-1) : k;
+
+              localVar(k,j,i) = localVar(kref,jref,iref);
+      });
+      break;
+    }
+
+    case axis: {
+      // Handling specific loop boundaries
+      int jref, offset;
+      if(side == left) {
+        jref = this->beg[JDIR];
+        offset = -1;
+      }
+      if(side == right) {
+        jref = this->end[JDIR]-1;
+        offset = 1;
+      }
+
+      // NB: we assume no domain decomposition along phi here
+
+      int np_int_k = this->np_int[KDIR];
+      int nghost_k = this->nghost[KDIR];
+
+      if(this->isTwoPi) {
+        idefix_for("BoundaryAxis",kbeg,kend,jbeg,jend,ibeg,iend,
+                KOKKOS_LAMBDA (int k, int j, int i) {
+                  int kcomp = nghost_k + (( k - nghost_k + np_int_k/2) % np_int_k);
+                  // Assuming sVc=1 for a scalar
+                  localVar(k,j,i) = localVar(kcomp, 2*jref-j+offset,i);
+                });
+      } else { // not 2pi
+        idefix_for("BoundaryAxis",kbeg,kend,jbeg,jend,ibeg,iend,
+                KOKKOS_LAMBDA (int k, int j, int i) {
+                  // kcomp = k by construction since we're doing a fraction of twopi
+                  // Assuming sVc=1 for a scalar
+                  localVar(k,j,i) = localVar(k, 2*jref-j+offset,i);
+                });
+      }
+      break;
+    }
+
+    case origin: {
+      // Assume the grid is extended inwards close to the origin. Hence the inner ghost
+      // all have the same value.
+      int iref = this->beg[IDIR];
+
+      real psiIn = 0.0;
+
+      idefix_reduce("meanPsiIn",
+                    beg[KDIR], end[KDIR],
+                    beg[JDIR], end[JDIR],
+                    KOKKOS_LAMBDA(int k, int j, real &psi) {
+                      psi += localVar(k,j,iref);
+                    },Kokkos::Sum<real> (psiIn));
+
+      #ifdef WITH_MPI
+        MPI_Allreduce(MPI_IN_PLACE, &psiIn, 1, realMPI, MPI_SUM, originComm);
+      #endif
+      // Do a mean by dividing by the number of points
+      psiIn = psiIn/(data->mygrid->np_int[JDIR]*data->mygrid->np_int[KDIR]);
+
+      // put this in the ghost cells
+      idefix_for("BoundaryOrigin",kbeg,kend,jbeg,jend,ibeg,iend,
+                KOKKOS_LAMBDA (int k, int j, int i) {
+                  localVar(k,j,i) = psiIn;
+                });
+      break;
+    }
+
+    default: {
+      std::stringstream msg ("SelfGravity:: Boundary condition type is not yet implemented");
+      IDEFIX_ERROR(msg);
+    }
+  }
+
+  idfx::popRegion();
+}
+
+
+void Laplacian::EnrollUserDefBoundary(UserDefBoundaryFunc myFunc) {
+  this->userDefBoundaryFunc = myFunc;
+  this->haveUserDefBoundary = true;
+}
+
+void Laplacian::SetBoundaries(IdefixArray3D<real> &arr) {
+  idfx::pushRegion("Laplacian::SetBoundaries");
+
+  #ifdef WITH_MPI
+  this->arr4D = IdefixArray4D<real> (arr.data(), 1, this->np_tot[KDIR],
+                                                    this->np_tot[JDIR],
+                                                    this->np_tot[IDIR]);
+  #endif
+
+  for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
+    // MPI Exchange data when needed
+    #ifdef WITH_MPI
+    if(data->mygrid->nproc[dir]>1) {
+      switch(dir) {
+        case 0:
+          this->mpi.ExchangeX1(this->arr4D);
+          break;
+        case 1:
+          this->mpi.ExchangeX2(this->arr4D);
+          break;
+        case 2:
+          this->mpi.ExchangeX3(this->arr4D);
+          break;
+      }
+    }
+    #endif
+
+    EnforceBoundary(dir, left, this->lbound[dir], arr);
+    EnforceBoundary(dir, right, this->rbound[dir], arr);
+  }
+
+  idfx::popRegion();
+}

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -46,6 +46,15 @@ Laplacian::Laplacian(DataBlock *datain, std::array<LaplacianBoundaryType,3> left
        rbound[dir] != LaplacianBoundaryType::internalgrav) isPeriodic = false;
   }
 
+  #ifdef WITH_MPI
+    if(lbound[IDIR] == origin) {
+      // create communicator for spherical radius
+      int remainDims[3] = {false, true, true};
+      MPI_SAFE_CALL(MPI_Cart_sub(data->mygrid->CartComm, remainDims, &originComm));
+    }
+  #endif
+
+
   #if GEOMETRY == SPHERICAL
     if ((this->rbound[JDIR]==axis) || (this->lbound[JDIR]==axis)) {
       // Check wether the x3 spherical axis is full two pi

--- a/src/gravity/laplacian.hpp
+++ b/src/gravity/laplacian.hpp
@@ -1,0 +1,83 @@
+// ***********************************************************************************
+// Idefix MHD astrophysical code
+// Copyright(C) Geoffroy R. J. Lesur <geoffroy.lesur@univ-grenoble-alpes.fr>
+// and other code contributors
+// Licensed under CeCILL 2.1 License, see COPYING for more information
+// ***********************************************************************************
+
+#ifndef GRAVITY_LAPLACIAN_HPP_
+#define GRAVITY_LAPLACIAN_HPP_
+
+#include "idefix.hpp"
+
+
+class Laplacian {
+ public:
+  Lapacian(DataBlock &, LaplacianBoundaryType &, LaplacianBoundaryType &, bool );
+
+  // Types of boundary which can be treated
+  enum LaplacianBoundaryType {internalgrav, periodic, nullgrad, nullpot, userdef, axis, origin};
+  void InitPreconditionner();   // For preconditionning versions
+  void PreComputeLaplacian();   // For faster Laplacian computation
+
+  void InitInternalGrid(); // initialise the extra internal grid (for origin BCs)
+
+  void SetBoundaries(IdefixArray3D<real> &);  // Set the proper boundaries for the given array
+
+  void EnrollUserDefBoundary(UserDefBoundaryFunc);  // Enroll user-defined boundary conditions
+
+  // The main laplacian operator
+  void operator() (IdefixArray3D<real> in,  IdefixArray3D<real> laplacian);
+
+  // Handling userdef boundary.
+  using UserDefBoundaryFunc = void (*) (DataBlock &, int dir, BoundarySide side,
+                                       const real t, IdefixArray3D<real> &arr);
+  void EnforceBoundary(int dir, BoundarySide side, GravityBoundaryType type,
+                       IdefixArray3D<real> &);
+  bool haveUserDefBoundary{false};
+  // User defined Boundary conditions
+  UserDefBoundaryFunc userDefBoundaryFunc{NULL};
+
+  // Local potential array size
+  std::vector<int> np_tot;
+  std::vector<int> np_int;
+
+  std::vector<int> nghost;
+  std::vector<int> beg;
+  std::vector<int> end;
+
+  // offset in the left and right direction between selfgravity grid and datablock grid
+  std::vector<int> loffset;
+  std::vector<int> roffset;
+
+  // Grid for self-gravity solver (note that this grid may extend the grid of the current datablock)
+  std::vector<IdefixArray1D<real>> x;    ///< geometrical central points
+  std::vector<IdefixArray1D<real>> dx;   ///< cell width
+
+  IdefixArray1D<real> sinx2;            ///< sinx2 (only in spherical)
+
+  IdefixArray3D<real> dV;                ///< cell volume
+  std::vector<IdefixArray3D<real>> A;    ///< cell left interface area
+
+  bool isPeriodic; // Periodicity status of the density distribution
+  std::array<LaplacianBoundaryType,3> lbound;  // Boundary condition to the left
+  std::array<LaplacianBoundaryType,3> rbound;  // Boundary condition to the right
+                           // Warning : might differ from (M)HD solver !
+
+  IdefixArray3D<real> precond; // Diagonal preconditionner
+  IdefixArray4D<real> Lx1; //< Laplacian operator in x1
+  IdefixArray4D<real> Lx2; //< Laplacian operator in x2
+  IdefixArray4D<real> Lx3; //< Laplacian operator in x3
+
+  bool isTwoPi{false};
+  bool havePreconditioner{false}; // Use of preconditionner (or not)
+
+
+  #ifdef WITH_MPI
+  Mpi mpi;  // Mpi object when WITH_MPI is set
+  IdefixArray4D<real> arr4D; // Intermediate array for boundary handling
+  #endif
+};
+
+
+#endif

--- a/src/gravity/laplacian.hpp
+++ b/src/gravity/laplacian.hpp
@@ -10,6 +10,9 @@
 
 #include <vector>
 #include "idefix.hpp"
+#ifdef WITH_MPI
+#include "mpi.hpp"
+#endif
 
 class DataBlock;
 

--- a/src/gravity/laplacian.hpp
+++ b/src/gravity/laplacian.hpp
@@ -89,6 +89,9 @@ class Laplacian {
   #ifdef WITH_MPI
   Mpi mpi;  // Mpi object when WITH_MPI is set
   IdefixArray4D<real> arr4D; // Intermediate array for boundary handling
+
+  MPI_Comm originComm;                  ///< MPI communicator used by the origin boundary condition
+
   #endif
 };
 

--- a/src/gravity/selfGravity.cpp
+++ b/src/gravity/selfGravity.cpp
@@ -174,28 +174,28 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
   }
 
   // Make the Laplacian operator
-  laplacian = std::make_unique<Laplacian>(data, lbound, rbound, this->havePreconditioner );
+  laplacian = Laplacian(data, lbound, rbound, this->havePreconditioner );
   
-  np_tot = laplacian->np_tot;
+  np_tot = laplacian.np_tot;
   
   // Instantiate the bicgstab solver
   if(solver == BICGSTAB || solver == PBICGSTAB) {
     iterativeSolver = new Bicgstab<SelfGravity>(this, laplacian,
                                                 targetError, maxiter,
-                                                laplacian->np_tot, laplacian->beg, laplacian->end);
+                                                laplacian.np_tot, laplacian.beg, laplacian.end);
   } else if(solver == CG || solver == PCG) {
     iterativeSolver = new Cg<SelfGravity>(this, laplacian,
                                                 targetError, maxiter,
-                                                laplacian->np_tot, laplacian->beg, laplacian->end);
+                                                laplacian.np_tot, laplacian.beg, laplacian.end);
   } else if(solver == MINRES || solver == PMINRES) {
     iterativeSolver = new Minres<SelfGravity>(this, laplacian,
                                                 targetError, maxiter,
-                                                laplacian->np_tot, laplacian->beg, laplacian->end);
+                                                laplacian.np_tot, laplacian.beg, laplacian.end);
   } else {
       real step = ComputeJacobiCFL();
       iterativeSolver = new Jacobi<SelfGravity>(this, laplacian,
                                                 targetError, maxiter, step,
-                                                laplacian->np_tot, laplacian->beg, laplacian->end);
+                                                laplacian.np_tot, laplacian.beg, laplacian.end);
   }
 
 
@@ -527,7 +527,7 @@ void SelfGravity::SubstractMeanDensity() {
 
 
 void SelfGravity::EnrollUserDefBoundary(UserDefBoundaryFunc myFunc) {
-  laplacian->EnrollUserDefBoundary(myFunc);
+  laplacian.EnrollUserDefBoundary(myFunc);
   idfx::cout << "SelfGravity:: User-defined boundary condition has been enrolled" << std::endl;
 }
 

--- a/src/gravity/selfGravity.cpp
+++ b/src/gravity/selfGravity.cpp
@@ -285,6 +285,19 @@ void SelfGravity::InitSolver() {
       density(k+koffset, j+joffset, i+ioffset) = Vc(RHO, k, j, i);
     });
 
+  // Make sure that dust mass contributes to the self-gravitating field
+  if(data->haveDust) {
+    for(int i = 0 ; i < data->dust.size() ; i++) {
+      IdefixArray4D<real> VcDust = data->dust[i]->Vc;
+      idefix_for("InitDustDensity", data->beg[KDIR], data->end[KDIR],
+                                    data->beg[JDIR], data->end[JDIR],
+                                    data->beg[IDIR], data->end[IDIR],
+        KOKKOS_LAMBDA (int k, int j, int i) {
+          density(k+koffset, j+joffset, i+ioffset) += VcDust(RHO, k, j, i);
+      });
+    }
+  }
+
   // Deal with the mean issue for periodic density distribution
   if(this->isPeriodic == true) {
     SubstractMeanDensity();  // Remove density mean

--- a/src/gravity/selfGravity.cpp
+++ b/src/gravity/selfGravity.cpp
@@ -74,12 +74,6 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
       if(dir != IDIR) {
         IDEFIX_ERROR("Origin boundary conditions are meaningful only on the X1 direction");
       }
-      #ifdef WITH_MPI
-        // create communicator for spherical radius
-        int remainDims[3] = {false, true, true};
-        MPI_SAFE_CALL(MPI_Cart_sub(data->mygrid->CartComm, remainDims, &originComm));
-      #endif
-
     } else {
       std::stringstream msg;
       msg << "SelfGravity:: Unknown boundary type " << boundary;
@@ -116,11 +110,11 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
   #ifdef WITH_MPI
   for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
     if(data->mygrid->nproc[dir]>1) {
-      if(this->data->lbound[dir]==internal) {
-        this->lbound[dir] = internalgrav;
+      if(this->data->lbound[dir]==internal ) {
+        this->lbound[dir] = Laplacian::internalgrav;
       }
       if(this->data->rbound[dir]==internal) {
-        this->rbound[dir] = internalgrav;
+        this->rbound[dir] = Laplacian::internalgrav;
       }
     }
   }

--- a/src/gravity/selfGravity.cpp
+++ b/src/gravity/selfGravity.cpp
@@ -54,24 +54,24 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
     std::string boundary = input.Get<std::string>("SelfGravity",label,0);
 
     if(boundary.compare("nullpot") == 0) {
-      this->lbound[dir] = nullpot;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::nullpot;
       this->isPeriodic = false;
     } else if(boundary.compare("periodic") == 0) {
-      this->lbound[dir] = periodic;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::periodic;
     } else if(boundary.compare("nullgrad") == 0) {
-      this->lbound[dir] = nullgrad;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::nullgrad;
       this->isPeriodic = false;
     } else if(boundary.compare("internalgrav") == 0) {
-      this->lbound[dir] = internalgrav;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::internalgrav;
       this->isPeriodic = false;
     } else if(boundary.compare("userdef") == 0) {
-      this->lbound[dir] = userdef;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::userdef;
       this->isPeriodic = false;
     } else if(boundary.compare("axis") == 0) {
-      this->lbound[dir] = axis;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::axis;
       this->isPeriodic = false;
     } else if(boundary.compare("origin") == 0) {
-      this->lbound[dir] = origin;
+      this->lbound[dir] = Laplacian::LaplacianBoundaryType::origin;
       this->isPeriodic = false;
       // origin only compatible with spherical & axis=IDIR
       #if GEOMETRY != SPHERICAL
@@ -95,21 +95,21 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
     label = std::string("boundary-X")+std::to_string(dir+1)+std::string("-end");
     boundary = input.Get<std::string>("SelfGravity",label,0);
     if(boundary.compare("nullpot") == 0) {
-      this->rbound[dir] = nullpot;
+      this->rbound[dir] = Laplacian::LaplacianBoundaryType::nullpot;
       this->isPeriodic = false;
     } else if(boundary.compare("periodic") == 0) {
-      this->rbound[dir] = periodic;
+      this->rbound[dir] = Laplacian::LaplacianBoundaryType::periodic;
     } else if(boundary.compare("nullgrad") == 0) {
-      this->rbound[dir] = nullgrad;
+      this->rbound[dir] = Laplacian::LaplacianBoundaryType::nullgrad;
       this->isPeriodic = false;
     } else if(boundary.compare("internalgrav") == 0) {
-      this->rbound[dir] = internalgrav;
+      this->rbound[dir] = Laplacian::LaplacianBoundaryType::internalgrav;
       this->isPeriodic = false;
     } else if(boundary.compare("userdef") == 0) {
-      this->rbound[dir] = userdef;
+      this->rbound[dir] = Laplacian::LaplacianBoundaryType::userdef;
       this->isPeriodic = false;
     } else if(boundary.compare("axis") == 0) {
-      this->rbound[dir] = axis;
+      this->rbound[dir] = Laplacian::LaplacianBoundaryType::axis;
       this->isPeriodic = false;
     } else {
       std::stringstream msg;
@@ -131,41 +131,6 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
     }
   }
   #endif
-
-  #if GEOMETRY == SPHERICAL
-    if ((this->rbound[JDIR]==axis) || (this->lbound[JDIR]==axis)) {
-      // Check wether the x3 spherical axis is full two pi
-      if(fabs((data->mygrid->xend[KDIR] - data->mygrid->xbeg[KDIR] -2.0*M_PI)) < 1e-10) {
-        this->isTwoPi = true;
-      }
-
-    #ifdef WITH_MPI
-      // Check that there is no domain decomposition in phi
-      if(data->mygrid->nproc[KDIR]>1) {
-        IDEFIX_ERROR("SelfGravity:: Axis boundaries are not compatible with "
-                     "MPI domain decomposition in X3");
-      }
-    #endif
-    }
-  #endif
-
-  // init the grid elements using the parent datablock
-  this->np_tot = data->np_tot;
-  this->np_int = data->np_int;
-  this->nghost = data->nghost;
-  this->beg = data->beg;
-  this->end = data->end;
-  this->x = data->x;
-  this->dx = data->dx;
-  this->sinx2 = data->sinx2;
-  this->dV = data->dV;
-  this->A = data->A;
-  this->loffset = std::vector<int>(3,0);
-  this->roffset = std::vector<int>(3,0);
-
-  if(this->lbound[IDIR] == origin) {
-    InitInternalGrid();
-  }
 
   // Update solver when provided
   if(input.CheckEntry("SelfGravity","solver") >= 0) {
@@ -208,32 +173,32 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
     this->havePreconditioner = true;
   }
 
+  // Make the Laplacian operator
+  laplacian = std::make_unique<Laplacian>(data, lbound, rbound, this->havePreconditioner );
+  
+  np_tot = laplacian->np_tot;
+  
   // Instantiate the bicgstab solver
   if(solver == BICGSTAB || solver == PBICGSTAB) {
-    iterativeSolver = new Bicgstab<SelfGravity>(this, &SelfGravity::ComputeLaplacian,
+    iterativeSolver = new Bicgstab<SelfGravity>(this, laplacian,
                                                 targetError, maxiter,
-                                                this->np_tot, this->beg, this->end);
+                                                laplacian->np_tot, laplacian->beg, laplacian->end);
   } else if(solver == CG || solver == PCG) {
-    iterativeSolver = new Cg<SelfGravity>(this, &SelfGravity::ComputeLaplacian,
+    iterativeSolver = new Cg<SelfGravity>(this, laplacian,
                                                 targetError, maxiter,
-                                                this->np_tot, this->beg, this->end);
+                                                laplacian->np_tot, laplacian->beg, laplacian->end);
   } else if(solver == MINRES || solver == PMINRES) {
-    iterativeSolver = new Minres<SelfGravity>(this, &SelfGravity::ComputeLaplacian,
+    iterativeSolver = new Minres<SelfGravity>(this, laplacian,
                                                 targetError, maxiter,
-                                                this->np_tot, this->beg, this->end);
+                                                laplacian->np_tot, laplacian->beg, laplacian->end);
   } else {
       real step = ComputeJacobiCFL();
-      iterativeSolver = new Jacobi<SelfGravity>(this, &SelfGravity::ComputeLaplacian,
+      iterativeSolver = new Jacobi<SelfGravity>(this, laplacian,
                                                 targetError, maxiter, step,
-                                                this->np_tot, this->beg, this->end);
+                                                laplacian->np_tot, laplacian->beg, laplacian->end);
   }
 
-  // Init preconditionner if needed
-  if(havePreconditioner) {
-    InitPreconditionner();
-  }
-  // Initialise the Laplacian coefficients
-  PreComputeLaplacian();
+
 
   // Arrays initialisation
   this->density = IdefixArray3D<real> ("Density", this->np_tot[KDIR],
@@ -252,154 +217,11 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
                                                       this->np_tot[JDIR],
                                                       this->np_tot[IDIR]);
 
-  // Init MPI stack when needed
-  #ifdef WITH_MPI
-  this->arr4D = IdefixArray4D<real> ("WorkingArrayMpi", 1, this->np_tot[KDIR],
-                                                           this->np_tot[JDIR],
-                                                           this->np_tot[IDIR]);
-
-  int ntarget = 0;
-  std::vector<int> mapVars;
-  mapVars.push_back(ntarget);
-
-  this->mpi.Init(data->mygrid, mapVars, this->nghost.data(), this->np_int.data());
-  #endif
-
-  idfx::popRegion();
-}
-
-void SelfGravity::InitInternalGrid() {
-  idfx::pushRegion("SelfGravity::InitInternalGrid");
-  // Extend the grid so that the inner radius will be 1/10 of the initial inner radius
-  GridHost gh(*data->mygrid);
-  gh.SyncFromDevice();
-
-  real dx0 = gh.dx[IDIR](0);
-  real rin = gh.xbeg[IDIR]/10.0;
-
-  loffset[IDIR] = (gh.xl[IDIR](0) - rin) / dx0;
-
-  this->np_tot[IDIR] += loffset[IDIR];
-  this->np_int[IDIR] += loffset[IDIR];
-  this->end[IDIR] += loffset[IDIR];
-
-  // Allocate required arrays
-  this->x[IDIR] = IdefixArray1D<real>("SG_x1", this->np_tot[IDIR]);
-  this->dx[IDIR] = IdefixArray1D<real>("SG_dx1", this->np_tot[IDIR]);
-  this->dV = IdefixArray3D<real>("SG_dV", this->np_tot[KDIR],
-                                          this->np_tot[JDIR],
-                                          this->np_tot[IDIR]);
-  for(int dir = 0 ; dir < 3 ; dir ++) {
-    this->A[dir] = IdefixArray3D<real>("SG_A", this->np_tot[KDIR]+KOFFSET,
-                                          this->np_tot[JDIR]+JOFFSET,
-                                          this->np_tot[IDIR]+IOFFSET);
-  }
-  // xl and xr are used only temporarily in this subroutine.
-  auto x1l = IdefixArray1D<real>("SG_x1l", this->np_tot[IDIR]);
-  auto x1r = IdefixArray1D<real>("SG_x1r", this->np_tot[IDIR]);
-  // incidentally, sinx2 is not affected by a grid extension in x1, so no need to
-  // allocate a new array
-
-
-  // Fill selfgravity with the existing datablock grid
-  int ioffset = loffset[IDIR];
-
-  auto x1in = data->x[IDIR];
-  auto x1lin = data->xl[IDIR];
-  auto x1rin = data->xr[IDIR];
-  auto dx1in = data->dx[IDIR];
-  auto x1 = this->x[IDIR];
-  auto dx1 = this->dx[IDIR];
-  idefix_for("InternalGridCopy",0, data->np_tot[IDIR],
-     KOKKOS_LAMBDA(int i) {
-       x1(i+ioffset) = x1in(i);
-       dx1(i+ioffset) = dx1in(i);
-       x1l(i+ioffset) = x1lin(i);
-       x1r(i+ioffset) = x1rin(i);
-     });
-
-  // extend with a uniform grid and spacing equal to first of the datablock
-  idefix_for("InternalGridFill",0, ioffset,
-     KOKKOS_LAMBDA(int i) {
-       const real dx0 = dx1(ioffset);
-       dx1(i) = dx0;
-       x1(i) = x1(ioffset) + (i-ioffset)*dx0;
-       x1l(i) = x1l(ioffset) + (i-ioffset)*dx0;
-       x1r(i) = x1l(ioffset) + (i-ioffset+1)*dx0;
-     });
-
-  // Check that all is well
-  IdefixArray1D<real>::HostMirror xH = Kokkos::create_mirror_view(x1l);
-  Kokkos::deep_copy(xH, x1l);
-
-  if(xH(0)<0.0) {
-    IDEFIX_ERROR("SelfGravity: Your grid extension goes beyond the origin!");
-  }
-
-  IdefixArray3D<real> dV  = this->dV;
-  //IdefixArray1D<real> dx1 = this->dx[IDIR];
-  IdefixArray1D<real> dx2 = this->dx[JDIR];
-  IdefixArray1D<real> dx3 = this->dx[KDIR];
-  //IdefixArray1D<real> x1  = this->x[IDIR];
-  IdefixArray1D<real> x2  = this->x[JDIR];
-  IdefixArray1D<real> x3  = this->x[KDIR];
-  IdefixArray1D<real> x1p = x1r;
-  IdefixArray1D<real> x2p = data->xr[JDIR];
-  IdefixArray1D<real> x3p = data->xr[KDIR];
-  IdefixArray1D<real> x1m = x1l;
-  IdefixArray1D<real> x2m = data->xl[JDIR];
-  IdefixArray1D<real> x3m = data->xl[KDIR];
-
-  // Fill the volume and area arrays (assume spherical geometry)
-  idefix_for("Volumes",0,this->np_tot[KDIR],0,this->np_tot[JDIR],0,this->np_tot[IDIR],
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      real dVr = FABS(x1p(i)*x1p(i)*x1p(i) - x1m(i)*x1m(i)*x1m(i))/3.0;
-      real dmu = FABS(cos(x2m(j)) - cos(x2p(j)));
-      dV(k,j,i) = D_EXPAND( dVr, *dmu, *dx3(k));
-    }
-  );
-
-  // Compute Areas
-  IdefixArray3D<real> Ax1 = this->A[IDIR];
-  IdefixArray3D<real> Ax2 = this->A[JDIR];
-  IdefixArray3D<real> Ax3 = this->A[KDIR];
-
-  // X1 direction
-  int end = this->np_tot[IDIR];
-  idefix_for("AreaX1",0,this->np_tot[KDIR],0,this->np_tot[JDIR],0,this->np_tot[IDIR]+IOFFSET,
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      real dmu = FABS(cos(x2m(j)) - cos(x2p(j)));
-      if(i == end) {
-        Ax1(k,j,i) = D_EXPAND(x1p(i-1)*x1p(i-1), *dmu, *dx3(k));
-      } else {
-        Ax1(k,j,i) = D_EXPAND(x1m(i)*x1m(i), *dmu, *dx3(k)); // r^2*dmu*dphi
-      }
-    });
-
-  // X2 direction
-  end = this->np_tot[JDIR];
-  idefix_for("AreaX2",0,this->np_tot[KDIR],0,this->np_tot[JDIR]+JOFFSET,0,this->np_tot[IDIR],
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      if (j == end) {
-        Ax2(k,j,i) = D_EXPAND(x1(i)*dx1(i), *FABS(sin(x2p(j-1))), *dx3(k));
-      } else {
-        Ax2(k,j,i) = D_EXPAND(x1(i)*dx1(i), *FABS(sin(x2m(j))), *dx3(k)); // = r*dr*sin(thp)*dphi
-      }
-    });
-
-  // X3 direction
-  end = this->np_tot[KDIR];
-  idefix_for("AreaX3",0,this->np_tot[KDIR]+KOFFSET,0,this->np_tot[JDIR],0,this->np_tot[IDIR],
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      Ax3(k,j,i) = D_EXPAND(x1(i)*dx1(i), *dx2(j), *ONE_F);   // = r*dr*dth
-    }
-  );
-
-
   
-
   idfx::popRegion();
 }
+
+
 
 void SelfGravity::ShowConfig() {
   idfx::cout << "SelfGravity: Using ";
@@ -450,89 +272,7 @@ void SelfGravity::ShowConfig() {
   iterativeSolver->ShowConfig();
 }
 
-void SelfGravity::InitPreconditionner() {
-  idfx::pushRegion("SelfGravity::InitPreconditioner");
-  IdefixArray3D<real> P = IdefixArray3D<real> ("Preconditionner", this->np_tot[KDIR],
-                                                                  this->np_tot[JDIR],
-                                                                  this->np_tot[IDIR]);
 
-  int ibeg, iend, jbeg, jend, kbeg, kend;
-  ibeg = this->beg[IDIR];
-  iend = this->end[IDIR];
-  jbeg = this->beg[JDIR];
-  jend = this->end[JDIR];
-  kbeg = this->beg[KDIR];
-  kend = this->end[KDIR];
-
-  // Set array to zero
-  idefix_for("ResetPrecond", kbeg, kend, jbeg, jend, ibeg, iend,
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      P(k,j,i) = 0;
-    });
-
-  IdefixArray3D<real> dV = this->dV;
-
-  #if (GEOMETRY==CYLINDRICAL) || (GEOMETRY==POLAR)
-  IdefixArray1D<real> r = this->x[IDIR];
-  #elif GEOMETRY==SPHERICAL
-  IdefixArray1D<real> r = this->x[IDIR];
-  IdefixArray1D<real> sinth = this->sinx2;
-  #endif
-
-  // Loop on dimensions to get the diagonal elements
-  for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
-    IdefixArray1D<real> dx = this->dx[dir];
-    IdefixArray3D<real> Ax = this->A[dir];
-    int ioffset = (dir == IDIR) ? 1 : 0;
-    int joffset = (dir == JDIR) ? 1 : 0;
-    int koffset = (dir == KDIR) ? 1 : 0;
-
-    idefix_for("InitPrecond", kbeg, kend, jbeg, jend, ibeg, iend,
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      int index = i*ioffset + j*joffset + k*koffset;
-      real dx0 = dx(index);
-      real dxm = dx(index-1);
-      real dxp = dx(index+1);
-
-      real Ap = Ax(k+koffset, j+joffset, i+ioffset);
-      real Am = Ax(k,j,i);
-
-      // Compute the diagonal elements coming from the laplacian
-      real d = -(2.0*Ap/(dx0+dxp) + 2.0*Am/(dx0+dxm)) / dV(k,j,i);
-
-      // Handling curvature terms
-      real h1, h2, h3;
-      #if GEOMETRY==CARTESIAN
-      h1=1.;
-      h2=1.;
-      h3=1.;
-      #elif GEOMETRY==CYLINDRICAL
-      h1=1.;
-      h2=1.;
-      h3=r(i); // Should never be used (cf. Idefix docu)
-      #elif GEOMETRY==POLAR
-      h1=1.;
-      h2=r(i);
-      h3=1.;
-      #else
-      h1=1.;
-      h2=r(i);
-      h3=r(i)*sinth(j);
-      #endif
-
-      // Full diagonal element (including curvature terms)
-      d = d/(h1*ioffset+h2*joffset+h3*koffset);
-
-      // We store in P the sum of all these elements
-      P(k,j,i) += d;
-    });
-  }
-
-  // Store the array for future use
-  this->precond = P;
-
-  idfx::popRegion();
-}
 
 void SelfGravity::InitSolver() {
   idfx::pushRegion("SelfGravity::InitSolver");
@@ -786,355 +526,11 @@ void SelfGravity::SubstractMeanDensity() {
 }
 
 
-void SelfGravity::PreComputeLaplacian() {
-  idfx::pushRegion("SelfGravity::PreComputeLaplacian");
-   // Precompute Laplacian Factor
-
-  // Allocate Laplacian factors
-  this->Lx1 = IdefixArray4D<real>("SelfGravity_Lx1",2, 
-                                                    this->np_tot[KDIR], 
-                                                    this->np_tot[JDIR],
-                                                    this->np_tot[IDIR]);
-  #if DIMENSIONS > 1
-    this->Lx2 = IdefixArray4D<real>("SelfGravity_Lx2",2, 
-                                                      this->np_tot[KDIR], 
-                                                      this->np_tot[JDIR],
-                                                      this->np_tot[IDIR]);
-
-    #if DIMENSIONS > 2
-      this->Lx3 = IdefixArray4D<real>("SelfGravity_Lx3",2, 
-                                                        this->np_tot[KDIR], 
-                                                        this->np_tot[JDIR],
-                                                        this->np_tot[IDIR]);
-    #endif
-  #endif
-
-
-  // Local copy of Laplacian arrays
-  IdefixArray4D<real> Lx1 = this->Lx1; // X stride
-  IdefixArray4D<real> Lx2 = this->Lx2; // Y stride
-  IdefixArray4D<real> Lx3 = this->Lx3; // Z stride
-
-
-  IdefixArray3D<real> P = this->precond;
-  bool havePreconditioner = this->havePreconditioner;
-  IdefixArray1D<real> dx1 = this->dx[IDIR];
-  IdefixArray1D<real> dx2 = this->dx[JDIR];
-  IdefixArray1D<real> dx3 = this->dx[KDIR];
-  IdefixArray3D<real> Ax1 = this->A[IDIR];
-  IdefixArray3D<real> Ax2 = this->A[JDIR];
-  IdefixArray3D<real> Ax3 = this->A[KDIR];
-  IdefixArray3D<real> dV = this->dV;
-  #if GEOMETRY == POLAR
-  IdefixArray1D<real> r = this->x[IDIR];
-  #elif GEOMETRY == SPHERICAL
-  IdefixArray1D<real> r = this->x[IDIR];
-  IdefixArray1D<real> sinth = this->sinx2;
-  #endif
-
-  idefix_for("L_Factor",KOFFSET,this->np_tot[KDIR]-KOFFSET,
-                        JOFFSET,this->np_tot[JDIR]-JOFFSET,
-                        IOFFSET,this->np_tot[IDIR]-JOFFSET,
-    KOKKOS_LAMBDA(int k, int j,int i) {
-      real h1, h2, h3;
-      #if GEOMETRY == CARTESIAN
-      h1 = 1.;
-      h2 = 1.;
-      h3 = 1.;
-      #elif GEOMETRY == POLAR
-      h1 = 1.;
-      h2 = r(i);
-      h3 = 1.;
-      #else
-      h1 = 1.;
-      h2 = r(i);
-      h3 = r(i) * sinth(j);
-      #endif
-
-      // i-1 coefficient
-      Lx1(0,k,j,i) = 2.0 * Ax1(k, j, i) / h1 / (dx1(i) + dx1(i-1)) / dV(k,j,i);
-      // i+1 coefficient
-      Lx1(1,k,j,i) = 2.0 * Ax1(k, j, i+1) / h1 / (dx1(i+1) + dx1(1)) / dV(k,j,i);
-      if(havePreconditioner) {
-        Lx1(0,k,j,i) /= P(k,j,i);
-        Lx1(1,k,j,i) /= P(k,j,i);
-      }
-      #if DIMENSIONS > 1
-        Lx2(0,k,j,i) = 2.0 * Ax2(k, j, i) / h2 / (dx2(j) + dx2(j-1)) / dV(k,j,i);
-        Lx2(1,k,j,i) = 2.0 * Ax2(k, j+1, i) / h2 / (dx2(j+1) + dx2(j)) / dV(k,j,i);
-        if(havePreconditioner) {
-          Lx2(0,k,j,i) /= P(k,j,i);
-          Lx2(1,k,j,i) /= P(k,j,i);
-        }
-        #if DIMENSIONS > 2
-          Lx3(0,k,j,i) = 2.0 * Ax3(k, j, i) / h3 / (dx3(k) + dx3(k-1)) / dV(k,j,i);
-          Lx3(1,k,j,i) = 2.0 * Ax3(k+1, j, i) / h3 / (dx3(k+1) + dx3(k)) / dV(k,j,i);
-          if(havePreconditioner) {
-            Lx3(0,k,j,i) /= P(k,j,i);
-            Lx3(1,k,j,i) /= P(k,j,i);
-          }
-        #endif
-      #endif
-      
-    });
-  idfx::popRegion();
-}
-
-
-void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real> laplacian) {
-  idfx::pushRegion("SelfGravity::ComputeLaplacian");
-
-  int ibeg, iend, jbeg, jend, kbeg, kend;
-  ibeg = this->beg[IDIR];
-  iend = this->end[IDIR];
-  jbeg = this->beg[JDIR];
-  jend = this->end[JDIR];
-  kbeg = this->beg[KDIR];
-  kend = this->end[KDIR];
-  IdefixArray4D<real> Lx1 = this->Lx1;
-  #if DIMENSIONS > 1
-  IdefixArray4D<real> Lx2 = this->Lx2;
-  #if DIMENSIONS > 2
-  IdefixArray4D<real> Lx3 = this->Lx3;
-  #endif
-  #endif
-
-  // Handling boundaries before laplacian calculation
-  this->SetBoundaries(array);
-
-  idefix_for("FiniteDifference", kbeg, kend, jbeg, jend, ibeg, iend,
-    KOKKOS_LAMBDA (int k, int j, int i) {
-      real gc = 0;
-      real Delta = 0;
-      real Lm, Lr;
-      #if DIMENSIONS > 2
-      Lm = Lx3(0,k,j,i);
-      Lr = Lx3(1,k,j,i);
-      gc += Lm + Lr;
-      Delta += array(k-1,j,i)*Lm + array(k+1,j,i)*Lr;
-      #endif
-      #if DIMENSIONS > 1
-        Lm = Lx2(0,k,j,i);
-        Lr = Lx2(1,k,j,i);
-        gc += Lm + Lr;
-        Delta += array(k,j-1,i)*Lm + array(k,j+1,i)*Lr;
-      #endif
-      Lm = Lx1(0,k,j,i);
-      Lr = Lx1(1,k,j,i);
-      gc += Lm + Lr;
-      Delta += array(k,j,i-1)*Lm + array(k,j,i+1)*Lr;
-
-      Delta -= gc * array(k,j,i);
-
-      laplacian(k, j, i) = Delta;
-    });
-
-
-
-  idfx::popRegion();
-}
-/*
-
-
-*/
-
-void SelfGravity::EnforceBoundary(int dir, BoundarySide side, GravityBoundaryType type,
-                                  IdefixArray3D<real> &arr) {
-  idfx::pushRegion("SelfGravity::EnforceBoundary");
-
-  IdefixArray3D<real> localVar = arr;
-
-  // Number of active cells
-  const int nxi = this->np_int[IDIR];
-  const int nxj = this->np_int[JDIR];
-  const int nxk = this->np_int[KDIR];
-
-  // Number of ghost cells
-  const int ighost = this->nghost[IDIR];
-  const int jghost = this->nghost[JDIR];
-  const int kghost = this->nghost[KDIR];
-
-  // Boundaries of the loop
-  const int ibeg = (dir == IDIR) ? side*(ighost+nxi) : 0;
-  const int iend = (dir == IDIR) ? ighost + side*(ighost+nxi) : this->np_tot[IDIR];
-  const int jbeg = (dir == JDIR) ? side*(jghost+nxj) : 0;
-  const int jend = (dir == JDIR) ? jghost + side*(jghost+nxj) : this->np_tot[JDIR];
-  const int kbeg = (dir == KDIR) ? side*(kghost+nxk) : 0;
-  const int kend = (dir == KDIR) ? kghost + side*(kghost+nxk) : this->np_tot[KDIR];
-
-  switch(type) {
-    case internalgrav:
-      // internal is used for MPI-enforced boundary conditions. Nothing to be done here.
-      break;
-
-    case periodic: {
-      if(data->mygrid->nproc[dir] > 1) break; // Periodicity already enforced by MPI calls
-
-      idefix_for("BoundaryPeriodic", kbeg, kend, jbeg, jend, ibeg, iend,
-            KOKKOS_LAMBDA (int k, int j, int i) {
-              int iref, jref, kref;
-              // This hack takes care of cases where we have more ghost zones than active zones
-              if(dir==IDIR)
-                iref = ighost + (i+ighost*(nxi-1))%nxi;
-              else
-                iref = i;
-              if(dir==JDIR)
-                jref = jghost + (j+jghost*(nxj-1))%nxj;
-              else
-                jref = j;
-              if(dir==KDIR)
-                kref = kghost + (k+kghost*(nxk-1))%nxk;
-              else
-                kref = k;
-
-              localVar(k,j,i) = localVar(kref,jref,iref);
-      });
-      break;
-    }
-
-    case userdef: {
-      if(this->haveUserDefBoundary) {
-        // Warning: unlike hydro userdef boundary functions, the selfGravity
-        // userdef boundary functions take an additional argument arr which
-        // specifies the array for which boundaries are to be handled
-        this->userDefBoundaryFunc(*data, dir, side, data->t, arr);
-      } else {
-        IDEFIX_ERROR("SelfGravity:: No function enrolled to define your own boundary conditions");
-      }
-      break;
-    }
-
-    case nullpot: {
-      idefix_for("BoundaryNullPot", kbeg, kend, jbeg, jend, ibeg, iend,
-            KOKKOS_LAMBDA (int k, int j, int i) {
-              localVar(k,j,i) = 0.0;
-      });
-      break;
-    }
-
-    case nullgrad: {
-      idefix_for("BoundaryNullGrad", kbeg, kend, jbeg, jend, ibeg, iend,
-            KOKKOS_LAMBDA (int k, int j, int i) {
-              const int iref = (dir==IDIR) ? ighost + side*(nxi-1) : i;
-              const int jref = (dir==JDIR) ? jghost + side*(nxj-1) : j;
-              const int kref = (dir==KDIR) ? kghost + side*(nxk-1) : k;
-
-              localVar(k,j,i) = localVar(kref,jref,iref);
-      });
-      break;
-    }
-
-    case axis: {
-      // Handling specific loop boundaries
-      int jref, offset;
-      if(side == left) {
-        jref = this->beg[JDIR];
-        offset = -1;
-      }
-      if(side == right) {
-        jref = this->end[JDIR]-1;
-        offset = 1;
-      }
-
-      // NB: we assume no domain decomposition along phi here
-
-      int np_int_k = this->np_int[KDIR];
-      int nghost_k = this->nghost[KDIR];
-
-      if(this->isTwoPi) {
-        idefix_for("BoundaryAxis",kbeg,kend,jbeg,jend,ibeg,iend,
-                KOKKOS_LAMBDA (int k, int j, int i) {
-                  int kcomp = nghost_k + (( k - nghost_k + np_int_k/2) % np_int_k);
-                  // Assuming sVc=1 for a scalar
-                  localVar(k,j,i) = localVar(kcomp, 2*jref-j+offset,i);
-                });
-      } else { // not 2pi
-        idefix_for("BoundaryAxis",kbeg,kend,jbeg,jend,ibeg,iend,
-                KOKKOS_LAMBDA (int k, int j, int i) {
-                  // kcomp = k by construction since we're doing a fraction of twopi
-                  // Assuming sVc=1 for a scalar
-                  localVar(k,j,i) = localVar(k, 2*jref-j+offset,i);
-                });
-      }
-      break;
-    }
-
-    case origin: {
-      // Assume the grid is extended inwards close to the origin. Hence the inner ghost
-      // all have the same value.
-      int iref = this->beg[IDIR];
-
-      real psiIn = 0.0;
-
-      idefix_reduce("meanPsiIn",
-                    beg[KDIR], end[KDIR],
-                    beg[JDIR], end[JDIR],
-                    KOKKOS_LAMBDA(int k, int j, real &psi) {
-                      psi += localVar(k,j,iref);
-                    },Kokkos::Sum<real> (psiIn));
-
-      #ifdef WITH_MPI
-        MPI_Allreduce(MPI_IN_PLACE, &psiIn, 1, realMPI, MPI_SUM, originComm);
-      #endif
-      // Do a mean by dividing by the number of points
-      psiIn = psiIn/(data->mygrid->np_int[JDIR]*data->mygrid->np_int[KDIR]);
-
-      // put this in the ghost cells
-      idefix_for("BoundaryOrigin",kbeg,kend,jbeg,jend,ibeg,iend,
-                KOKKOS_LAMBDA (int k, int j, int i) {
-                  localVar(k,j,i) = psiIn;
-                });
-      break;
-    }
-
-    default: {
-      std::stringstream msg ("SelfGravity:: Boundary condition type is not yet implemented");
-      IDEFIX_ERROR(msg);
-    }
-  }
-
-  idfx::popRegion();
-}
-
 void SelfGravity::EnrollUserDefBoundary(UserDefBoundaryFunc myFunc) {
-  this->userDefBoundaryFunc = myFunc;
-  this->haveUserDefBoundary = true;
+  laplacian->EnrollUserDefBoundary(myFunc);
   idfx::cout << "SelfGravity:: User-defined boundary condition has been enrolled" << std::endl;
 }
 
-void SelfGravity::SetBoundaries(IdefixArray3D<real> &arr) {
-  idfx::pushRegion("SelfGravity::SetBoundaries");
-
-  #ifdef WITH_MPI
-  this->arr4D = IdefixArray4D<real> (arr.data(), 1, this->np_tot[KDIR],
-                                                    this->np_tot[JDIR],
-                                                    this->np_tot[IDIR]);
-  #endif
-
-  for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
-    // MPI Exchange data when needed
-    #ifdef WITH_MPI
-    if(data->mygrid->nproc[dir]>1) {
-      switch(dir) {
-        case 0:
-          this->mpi.ExchangeX1(this->arr4D);
-          break;
-        case 1:
-          this->mpi.ExchangeX2(this->arr4D);
-          break;
-        case 2:
-          this->mpi.ExchangeX3(this->arr4D);
-          break;
-      }
-    }
-    #endif
-
-    EnforceBoundary(dir, left, this->lbound[dir], arr);
-    EnforceBoundary(dir, right, this->rbound[dir], arr);
-  }
-
-  idfx::popRegion();
-}
 
 
 

--- a/src/gravity/selfGravity.cpp
+++ b/src/gravity/selfGravity.cpp
@@ -884,6 +884,9 @@ void SelfGravity::PreComputeLaplacian() {
 void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real> laplacian) {
   idfx::pushRegion("SelfGravity::ComputeLaplacian");
 
+  // Tilling factor
+  constexpr int m = 4;
+
   int ibeg, iend, jbeg, jend, kbeg, kend;
   ibeg = this->beg[IDIR];
   iend = this->end[IDIR];
@@ -891,6 +894,11 @@ void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real
   jend = this->end[JDIR];
   kbeg = this->beg[KDIR];
   kend = this->end[KDIR];
+
+  // Renormalize by tilling factor
+  int jendTile = jbeg + (jend-jbeg)/m;
+  
+
   IdefixArray4D<real> Lx1 = this->Lx1;
   #if DIMENSIONS > 1
   IdefixArray4D<real> Lx2 = this->Lx2;
@@ -901,34 +909,120 @@ void SelfGravity::ComputeLaplacian(IdefixArray3D<real> array, IdefixArray3D<real
 
   // Handling boundaries before laplacian calculation
   this->SetBoundaries(array);
-
-  idefix_for("FiniteDifference", kbeg, kend, jbeg, jend, ibeg, iend,
+  // Init the array to constants
+  /*
+  idefix_for("Init", 0, this->np_tot[KDIR], 
+                                 0, this->np_tot[JDIR], 
+                                 0, this->np_tot[IDIR],
     KOKKOS_LAMBDA (int k, int j, int i) {
-      real gc = 0;
-      real Delta = 0;
-      real Lm, Lr;
+        array(k,j,i) = 1.0;
+    });*/
+
+
+  idefix_for("FiniteDifference", kbeg, kend, jbeg, jendTile, ibeg, iend,
+    KOKKOS_LAMBDA (int k, int jtile, int i) {
+      int js = jbeg + (jtile-jbeg)*m;
+      // Abord if outside of till
+      if(js>=jend) return;
+
+      real Lc[m];
+      real center[m];
+      real Delta[m];
+      for(int n = 0 ; n < m; n++) {
+        Lc[n] = 0;
+        Delta[n] = 0;
+      }
+      real L;
+
+
       #if DIMENSIONS > 2
-      Lm = Lx3(0,k,j,i);
-      Lr = Lx3(1,k,j,i);
-      gc += Lm + Lr;
-      Delta += array(k-1,j,i)*Lm + array(k+1,j,i)*Lr;
+        for(int n = 0 ; n < m; n++) {
+          if(js+n<jend) {
+            real L = Lx3(0,k,js+n,i);
+            Lc[n] += L;
+            Delta[n] += array(k-1,js+n,i)*L;
+          }
+        }
       #endif
+
+      // y=0
       #if DIMENSIONS > 1
-        Lm = Lx2(0,k,j,i);
-        Lr = Lx2(1,k,j,i);
-        gc += Lm + Lr;
-        Delta += array(k,j-1,i)*Lm + array(k,j+1,i)*Lr;
+      L = Lx2(0,k,js,i);
+      Lc[0] += L;
+      Delta[0] += array(k,js-1,i) * L;
+      # endif
+
+      // x loop
+      for(int n = 0 ; n < m; n++) {
+        // i-1
+        if(js+n<jend) {
+          real L = Lx1(0,k,js+n,i);
+          Lc[n] += L;
+          Delta[n] += array(k,js+n,i-1)*L;
+
+          // i = 0
+          center[n] = array(k,js+n,i);
+
+          // i+1
+          L = Lx1(1,k,js+n,i);
+          Lc[n] += L;
+          Delta[n] += array(k,js+n,i+1)*L;
+
+          #if DIMENSIONS > 1
+            if(n>0) {
+              //j+1 value
+              real L = Lx2(1,k,js+n-1,i);
+              Lc[n-1] += L;
+              Delta[n-1] += center[n] * L;
+            }
+            if(n < m-1) {
+              // j-1 value
+              real L = Lx2(0,k,js+n+1,i);
+              Lc[n+1] += L;
+              Delta[n+1] += center[n] * L;
+            }
+          #endif
+        }
+      }
+
+      // Last y loop
+      #if DIMENSIONS > 1
+        if(js+m-1<=jend) {
+          L = Lx2(1,k,js+m-1,i);
+          Lc[m-1] += L;
+          Delta[m-1] += array(k,js+m,i) * L;
+        }
+      # endif
+
+      // Last z loop
+      #if DIMENSIONS > 2
+      for(int n = 0 ; n < m; n++) {
+        if(js+n<jend) {
+          L = Lx3(1,k,js+n,i);
+          Lc[n] += L;
+          Delta[n] += array(k+1,js+n,i)*L;
+        }
+      }
       #endif
-      Lm = Lx1(0,k,j,i);
-      Lr = Lx1(1,k,j,i);
-      gc += Lm + Lr;
-      Delta += array(k,j,i-1)*Lm + array(k,j,i+1)*Lr;
 
-      Delta -= gc * array(k,j,i);
+      for(int n = 0 ; n < m; n++) {
+        // Substract middle values
+        if(js+n<jend) {
+          laplacian(k, js+n, i) = Delta[n] - Lc[n] * center[n];
+        }
+      }
 
-      laplacian(k, j, i) = Delta;
     });
+/*
+  idfx::cout << "FYI jbeg=" << jbeg << " ; jend=" << jend << std::endl;
+  idefix_for("Finish", kbeg, kend, jbeg, jend, ibeg, iend,
+    KOKKOS_LAMBDA (int k, int j, int i) {
+        if(fabs(laplacian(k,j,i) > 1e-7)) {
+          idfx::cout << "error at (" << i << "," << j << "," << k << ")=" << laplacian(k,j,i) << std::endl; 
+        }
+    });*/
 
+  //IDEFIX_ERROR("bloup");
 
 
   idfx::popRegion();

--- a/src/gravity/selfGravity.hpp
+++ b/src/gravity/selfGravity.hpp
@@ -41,7 +41,8 @@ class SelfGravity {
 
   IterativeSolver<Laplacian> *iterativeSolver;
 
-  std::unique_ptr<Laplacian> laplacian;
+  // The linear operator involved in Poisson equation
+  Laplacian laplacian;
 
   #ifdef DEBUG_GRAVITY
   // Used to get fields usefull for debugging

--- a/src/gravity/selfGravity.hpp
+++ b/src/gravity/selfGravity.hpp
@@ -58,6 +58,7 @@ class SelfGravity {
   void AddSelfGravityPotential(IdefixArray3D<real> &);
   void EnrollUserDefBoundary(UserDefBoundaryFunc);  // Enroll user-defined boundary conditions
   void InitPreconditionner();   // For preconditionning versions
+  void PreComputeLaplacian();   // For faster Laplacian computation
 
   // real gravCst; // 4*pi*G
 
@@ -124,6 +125,9 @@ class SelfGravity {
                            // Warning : might differ from (M)HD solver !
 
   IdefixArray3D<real> precond; // Diagonal preconditionner
+  IdefixArray4D<real> Lx1; //< Laplacian operator in x1
+  IdefixArray4D<real> Lx2; //< Laplacian operator in x2
+  IdefixArray4D<real> Lx3; //< Laplacian operator in x3
 
   #ifdef WITH_MPI
   IdefixArray4D<real> arr4D; // Intermediate array for boundary handling

--- a/src/gravity/selfGravity.hpp
+++ b/src/gravity/selfGravity.hpp
@@ -15,6 +15,7 @@
 #include "grid.hpp"
 #include "fluid_defs.hpp"
 #include "iterativesolver.hpp"
+#include "laplacian.hpp"
 
 #ifdef WITH_MPI
 #include "mpi.hpp"
@@ -25,52 +26,22 @@ class DataBlock;
 
 class SelfGravity {
  public:
-  // Types of boundary which can be treated
-  enum GravityBoundaryType {internalgrav, periodic, nullgrad, nullpot, userdef, axis, origin};
-  enum GravitySolver {JACOBI, BICGSTAB, PBICGSTAB, PCG, CG, PMINRES, MINRES};
 
-  // Handling userdef boundary.
-  using UserDefBoundaryFunc = void (*) (DataBlock &, int dir, BoundarySide side,
-                                       const real t, IdefixArray3D<real> &arr);
+  enum GravitySolver {JACOBI, BICGSTAB, PBICGSTAB, PCG, CG, PMINRES, MINRES};
 
   SelfGravity();  // Default (empty) constructor
   void Init(Input &, DataBlock *);  // Initialisation of the class attributes
   void ShowConfig();                // display current configuration
   void InitSolver(); // (Re)initialisation of the solver for a given density distribution
 
-  void InitInternalGrid(); // initialise the extra internal grid (for origin BCs)
-  real ComputeJacobiCFL();  // Compute step for Jacobi following CFL conditions
   void SubstractMeanDensity();  // Compute and substract the average input density
-
-  void ComputeLaplacian(IdefixArray3D<real> array,
-                        IdefixArray3D<real> laplacian);
-  // Compute the laplacian of the given array
-
-  void EnforceBoundary(int dir, BoundarySide side, GravityBoundaryType type,
-                       IdefixArray3D<real> &);
-  // Enforce boundary conditions in a specific dir, side, following boundary type
-  // and for the specified array
-
-  void SetBoundaries(IdefixArray3D<real> &);  // Set the proper boundaries for the given array
-
 
   void SolvePoisson(); // Solve Poisson equation
   void AddSelfGravityPotential(IdefixArray3D<real> &);
-  void EnrollUserDefBoundary(UserDefBoundaryFunc);  // Enroll user-defined boundary conditions
-  void InitPreconditionner();   // For preconditionning versions
-  void PreComputeLaplacian();   // For faster Laplacian computation
 
-  // real gravCst; // 4*pi*G
+  IterativeSolver<Laplacian> *iterativeSolver;
 
-  // User defined Boundary conditions
-  UserDefBoundaryFunc userDefBoundaryFunc{NULL};
-  bool haveUserDefBoundary{false};
-
-  IterativeSolver<SelfGravity> *iterativeSolver;
-
-  #ifdef WITH_MPI
-  Mpi mpi;  // Mpi object when WITH_MPI is set
-  #endif
+  std::unique_ptr<Laplacian> laplacian;
 
   #ifdef DEBUG_GRAVITY
   // Used to get fields usefull for debugging
@@ -93,51 +64,14 @@ class SelfGravity {
   IdefixArray3D<real> potential;  // Gravitational potential
   IdefixArray3D<real> density;  // Density
   real dt;  // CFL timestep
-
+  
   // Local potential array size
   std::vector<int> np_tot;
-  std::vector<int> np_int;
 
-  std::vector<int> nghost;
-  std::vector<int> beg;
-  std::vector<int> end;
-
-  // offset in the left and right direction between selfgravity grid and datablock grid
-  std::vector<int> loffset;
-  std::vector<int> roffset;
-
-  // Grid for self-gravity solver (note that this grid may extend the grid of the current datablock)
-  std::vector<IdefixArray1D<real>> x;    ///< geometrical central points
-  std::vector<IdefixArray1D<real>> dx;   ///< cell width
-
-  IdefixArray1D<real> sinx2;            ///< sinx2 (only in spherical)
-
-  IdefixArray3D<real> dV;                ///< cell volume
-  std::vector<IdefixArray3D<real>> A;    ///< cell left interface area
-
-  #ifdef WITH_MPI
-  MPI_Comm originComm;                  ///< MPI communicator used by the origin boundary condition
-  #endif
-
-  bool isPeriodic; // Periodicity status of the density distribution
-  GravityBoundaryType lbound[3];  // Boundary condition to the left
-  GravityBoundaryType rbound[3];  // Boundary condition to the right
-                           // Warning : might differ from (M)HD solver !
-
-  IdefixArray3D<real> precond; // Diagonal preconditionner
-  IdefixArray4D<real> Lx1; //< Laplacian operator in x1
-  IdefixArray4D<real> Lx2; //< Laplacian operator in x2
-  IdefixArray4D<real> Lx3; //< Laplacian operator in x3
-
-  #ifdef WITH_MPI
-  IdefixArray4D<real> arr4D; // Intermediate array for boundary handling
-  #endif
-
-  bool isTwoPi{false};
+  std::array<Laplacian::LaplacianBoundaryType,3> lbound;  // Boundary condition to the left
+  std::array<Laplacian::LaplacianBoundaryType,3> rbound;  // Boundary condition to the right
 
   GravitySolver solver; // The solver  used to solve Poisson
-
-  bool havePreconditioner{false}; // Use of preconditionner (or not)
 };
 
 #endif // GRAVITY_SELFGRAVITY_HPP_

--- a/src/gravity/selfGravity.hpp
+++ b/src/gravity/selfGravity.hpp
@@ -26,10 +26,8 @@ class DataBlock;
 
 class SelfGravity {
  public:
-
   enum GravitySolver {JACOBI, BICGSTAB, PBICGSTAB, PCG, CG, PMINRES, MINRES};
 
-  SelfGravity();  // Default (empty) constructor
   void Init(Input &, DataBlock *);  // Initialisation of the class attributes
   void ShowConfig();                // display current configuration
   void InitSolver(); // (Re)initialisation of the solver for a given density distribution
@@ -38,6 +36,8 @@ class SelfGravity {
 
   void SolvePoisson(); // Solve Poisson equation
   void AddSelfGravityPotential(IdefixArray3D<real> &);
+
+  void EnrollUserDefBoundary(Laplacian::UserDefBoundaryFunc myFunc);  // User-defined boundary
 
   IterativeSolver<Laplacian> *iterativeSolver;
 
@@ -65,13 +65,15 @@ class SelfGravity {
   IdefixArray3D<real> potential;  // Gravitational potential
   IdefixArray3D<real> density;  // Density
   real dt;  // CFL timestep
-  
+
   // Local potential array size
   std::vector<int> np_tot;
 
   std::array<Laplacian::LaplacianBoundaryType,3> lbound;  // Boundary condition to the left
   std::array<Laplacian::LaplacianBoundaryType,3> rbound;  // Boundary condition to the right
 
+  bool isPeriodic;
+  bool havePreconditioner{false};
   GravitySolver solver; // The solver  used to solve Poisson
 };
 

--- a/src/utils/iterativesolver/bicgstab.hpp
+++ b/src/utils/iterativesolver/bicgstab.hpp
@@ -13,12 +13,10 @@
 #include "iterativesolver.hpp"
 
 // The bicgstab derives from the iterativesolver class
-template <class C>
-class Bicgstab : public IterativeSolver<C> {
-  using LinearFunction = void(C::*) (IdefixArray3D<real> in, IdefixArray3D<real> out);
-
+template <class T>
+class Bicgstab : public IterativeSolver<T> {
  public:
-  Bicgstab(C *parent, LinearFunction func, real error, int maxIter,
+  Bicgstab(T *parent, LinearFunction func, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
@@ -40,10 +38,10 @@ class Bicgstab : public IterativeSolver<C> {
   IdefixArray3D<real> work3; // work array
 };
 
-template <class C>
-Bicgstab<C>::Bicgstab(C *p, LinearFunction f, real error, int maxiter,
+template <class T>
+Bicgstab<C>::Bicgstab(T *p, real error, int maxiter,
             std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
-            IterativeSolver<C>(p, f, error, maxiter, ntot, beg, end) {
+            IterativeSolver<T>(p, error, maxiter, ntot, beg, end) {
   // BICGSTAB scalars initialisation
   this->rho = 1.0;
   this->alpha = 1.0;

--- a/src/utils/iterativesolver/bicgstab.hpp
+++ b/src/utils/iterativesolver/bicgstab.hpp
@@ -16,7 +16,7 @@
 template <class T>
 class Bicgstab : public IterativeSolver<T> {
  public:
-  Bicgstab(T &op, LinearFunction func, real error, int maxIter,
+  Bicgstab(T &op, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
@@ -115,7 +115,7 @@ void Bicgstab<T>::InitSolver() {
 
   Kokkos::deep_copy(this->res0, this->res); // (Re)setting reference residual
   Kokkos::deep_copy(this->dir, this->res); // (Re)setting initial searching direction
-  linearOperator(this->dir, this->work1); // (Re)setting associated laplacian
+  this->linearOperator(this->dir, this->work1); // (Re)setting associated laplacian
 
   // // Resetting parameters
   // this->rho = 1.0;
@@ -191,7 +191,7 @@ void Bicgstab<T>::PerformIter() {
   // From now dir is updated
 
   // ***** Step 4.
-  linearOperator(dir, v);
+  this->linearOperator(dir, v);
 
   // from now v is updated (laplacian of dir)
 
@@ -241,7 +241,7 @@ void Bicgstab<T>::PerformIter() {
     // From here s is updated
 
     // ************** Step 9.
-    linearOperator(s, t);
+    this->linearOperator(s, t);
 
     // From here t is updated
 

--- a/src/utils/iterativesolver/cg.hpp
+++ b/src/utils/iterativesolver/cg.hpp
@@ -17,7 +17,7 @@ template <class T>
 class Cg : public IterativeSolver<T> {
 
  public:
-  Cg(C *parent, real error, int maxIter,
+  Cg(T &op, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
@@ -32,9 +32,9 @@ class Cg : public IterativeSolver<T> {
 };
 
 template <class T>
-Cg<T>::Cg(T *p, real error, int maxiter,
+Cg<T>::Cg(T &op, real error, int maxiter,
             std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
-            IterativeSolver<T>(p, f, error, maxiter, ntot, beg, end) {
+            IterativeSolver<T>(op, error, maxiter, ntot, beg, end) {
   // CG scalars initialisation
 
   this->p1 = IdefixArray3D<real> ("p1", this->ntot[KDIR],
@@ -105,7 +105,7 @@ void Cg<T>::PerformIter() {
   kend = this->end[KDIR];
 
   // ***** Step 1.
-  (this->parent->*(this->myFunc))(p1, s1);
+  linearOperator(p1, s1);
 
   real rr = this->ComputeDotProduct(r,r);
   //idfx::cout << "rr=" << rr << std::endl;

--- a/src/utils/iterativesolver/cg.hpp
+++ b/src/utils/iterativesolver/cg.hpp
@@ -15,7 +15,6 @@
 // The conjugate gradient derives from the iterativesolver class
 template <class T>
 class Cg : public IterativeSolver<T> {
-
  public:
   Cg(T &op, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
@@ -105,7 +104,7 @@ void Cg<T>::PerformIter() {
   kend = this->end[KDIR];
 
   // ***** Step 1.
-  linearOperator(p1, s1);
+  this->linearOperator(p1, s1);
 
   real rr = this->ComputeDotProduct(r,r);
   //idfx::cout << "rr=" << rr << std::endl;

--- a/src/utils/iterativesolver/cg.hpp
+++ b/src/utils/iterativesolver/cg.hpp
@@ -13,12 +13,11 @@
 #include "iterativesolver.hpp"
 
 // The conjugate gradient derives from the iterativesolver class
-template <class C>
-class Cg : public IterativeSolver<C> {
-  using LinearFunction = void(C::*) (IdefixArray3D<real> in, IdefixArray3D<real> out);
+template <class T>
+class Cg : public IterativeSolver<T> {
 
  public:
-  Cg(C *parent, LinearFunction func, real error, int maxIter,
+  Cg(C *parent, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
@@ -32,10 +31,10 @@ class Cg : public IterativeSolver<C> {
   IdefixArray3D<real> s1; // Search direction for gradient descent
 };
 
-template <class C>
-Cg<C>::Cg(C *p, LinearFunction f, real error, int maxiter,
+template <class T>
+Cg<T>::Cg(T *p, real error, int maxiter,
             std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
-            IterativeSolver<C>(p, f, error, maxiter, ntot, beg, end) {
+            IterativeSolver<T>(p, f, error, maxiter, ntot, beg, end) {
   // CG scalars initialisation
 
   this->p1 = IdefixArray3D<real> ("p1", this->ntot[KDIR],
@@ -48,8 +47,8 @@ Cg<C>::Cg(C *p, LinearFunction f, real error, int maxiter,
                                                 this->ntot[IDIR]);
 }
 
-template <class C>
-int Cg<C>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
+template <class T>
+int Cg<T>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
   idfx::pushRegion("Cg::Solve");
   this->solution = guess;
   this->rhs = rhs;
@@ -76,8 +75,8 @@ int Cg<C>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
   return(n);
 }
 
-template <class C>
-void Cg<C>::InitSolver() {
+template <class T>
+void Cg<T>::InitSolver() {
   idfx::pushRegion("Cg::InitSolver");
   // Residual initialisation
   this->SetRes();
@@ -87,8 +86,8 @@ void Cg<C>::InitSolver() {
   idfx::popRegion();
 }
 
-template <class C>
-void Cg<C>::PerformIter() {
+template <class T>
+void Cg<T>::PerformIter() {
   idfx::pushRegion("Cg::PerformIter");
 
   // Loading needed attributes
@@ -150,8 +149,8 @@ void Cg<C>::PerformIter() {
 
 
 
-template <class C>
-void Cg<C>::ShowConfig() {
+template <class T>
+void Cg<T>::ShowConfig() {
   idfx::pushRegion("Cg::ShowConfig");
   idfx::cout << "Cg: TargetError: " << this->targetError << std::endl;
   idfx::cout << "Cg: Maximum iterations: " << this->maxiter << std::endl;

--- a/src/utils/iterativesolver/iterativesolver.hpp
+++ b/src/utils/iterativesolver/iterativesolver.hpp
@@ -15,7 +15,6 @@
 template <class T>
 class IterativeSolver {
  public:
-
   IterativeSolver(T &op, real error, int maxIter,
                   std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
@@ -58,7 +57,6 @@ IterativeSolver<T>::IterativeSolver(T &op, real error, int maxiter,
   this->end = end;
   this->ntot = ntot;
   this->restart = false;
-  this->parent = p;
   this->currentError = 0;
   this->res = IdefixArray3D<real> ("Residual", this->ntot[KDIR],
                                               this->ntot[JDIR],
@@ -255,8 +253,8 @@ void IterativeSolver<T>::SetRes() {
   IdefixArray3D<real> solution = this->solution;
   IdefixArray3D<real> res = this->res;
 
-  // Computing laplacian
-  (parent->*myFunc)(solution, res); // We store function output in res to spare workRes array
+  // Computing operator
+  this->linearOperator(solution, res); // We store function output in res to spare workRes array
 
   int ibeg, iend, jbeg, jend, kbeg, kend;
   ibeg = this->beg[IDIR];

--- a/src/utils/iterativesolver/iterativesolver.hpp
+++ b/src/utils/iterativesolver/iterativesolver.hpp
@@ -16,7 +16,7 @@ template <class T>
 class IterativeSolver {
  public:
 
-  IterativeSolver(T *op, real error, int maxIter,
+  IterativeSolver(T &op, real error, int maxIter,
                   std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   real GetError();  // return the current error of the solver
@@ -32,7 +32,7 @@ class IterativeSolver {
   real ComputeDotProduct(IdefixArray3D<real> mat1, IdefixArray3D<real> mat2);
 
  protected:
-  T * linearOperator;
+  T & linearOperator;
   real currentError;
   real targetError;
   int maxiter;        // Maximum iteration allowed to achieve convergence
@@ -48,10 +48,10 @@ class IterativeSolver {
   IdefixArray3D<real> res; // Residual
 };
 
-template <class C>
-IterativeSolver<C>::IterativeSolver(C *p, LinearFunction f, real error, int maxiter,
-            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) {
-  this->myFunc = f;
+template <class T>
+IterativeSolver<T>::IterativeSolver(T &op, real error, int maxiter,
+            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end)
+              : linearOperator(op) {
   this->targetError = error;
   this->maxiter = maxiter;
   this->beg = beg;
@@ -65,8 +65,8 @@ IterativeSolver<C>::IterativeSolver(C *p, LinearFunction f, real error, int maxi
                                               this->ntot[IDIR]);
 }
 
-template <class C>
-void IterativeSolver<C>::TestErrorL1() {
+template <class T>
+void IterativeSolver<T>::TestErrorL1() {
   idfx::pushRegion("IterativeSolver::TestErrorL1");
 
   // Loading needed attributes
@@ -123,8 +123,8 @@ void IterativeSolver<C>::TestErrorL1() {
   idfx::popRegion();
 }
 
-template <class C>
-void IterativeSolver<C>::TestErrorL2() {
+template <class T>
+void IterativeSolver<T>::TestErrorL2() {
   idfx::pushRegion("IterativeSolver::TestErrorL2");
 
   // Loading needed attributes
@@ -181,8 +181,8 @@ void IterativeSolver<C>::TestErrorL2() {
   idfx::popRegion();
 }
 
-template <class C>
-void IterativeSolver<C>::TestErrorLINF() {
+template <class T>
+void IterativeSolver<T>::TestErrorLINF() {
   idfx::pushRegion("IterativeSolver::TestErrorLINF");
 
   // Loading needed attributes
@@ -246,8 +246,8 @@ void IterativeSolver<C>::TestErrorLINF() {
   idfx::popRegion();
 }
 
-template <class C>
-void IterativeSolver<C>::SetRes() {
+template <class T>
+void IterativeSolver<T>::SetRes() {
   idfx::pushRegion("IterativeSolver::SetRes");
 
   // Loading needed attributes
@@ -275,8 +275,8 @@ void IterativeSolver<C>::SetRes() {
   idfx::popRegion();
 }
 
-template <class C>
-real IterativeSolver<C>::ComputeDotProduct(IdefixArray3D<real> mat1, IdefixArray3D<real> mat2) {
+template <class T>
+real IterativeSolver<T>::ComputeDotProduct(IdefixArray3D<real> mat1, IdefixArray3D<real> mat2) {
   idfx::pushRegion("IterativeSolver::ComputeDotProduct");
 
   int ibeg, iend, jbeg, jend, kbeg, kend;
@@ -309,8 +309,8 @@ real IterativeSolver<C>::ComputeDotProduct(IdefixArray3D<real> mat1, IdefixArray
 }
 
 
-template <class C>
-real IterativeSolver<C>::GetError() {
+template <class T>
+real IterativeSolver<T>::GetError() {
   return(currentError);
 }
 

--- a/src/utils/iterativesolver/iterativesolver.hpp
+++ b/src/utils/iterativesolver/iterativesolver.hpp
@@ -12,12 +12,11 @@
 #include "idefix.hpp"
 #include "vector.hpp"
 
-template <class C>
+template <class T>
 class IterativeSolver {
  public:
-  using LinearFunction = void(C::*) (IdefixArray3D<real> in, IdefixArray3D<real> out);
 
-  IterativeSolver(C *parent, LinearFunction func, real error, int maxIter,
+  IterativeSolver(T *op, real error, int maxIter,
                   std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   real GetError();  // return the current error of the solver
@@ -33,10 +32,9 @@ class IterativeSolver {
   real ComputeDotProduct(IdefixArray3D<real> mat1, IdefixArray3D<real> mat2);
 
  protected:
-  LinearFunction myFunc;
+  T * linearOperator;
   real currentError;
   real targetError;
-  C *parent;          // parent class
   int maxiter;        // Maximum iteration allowed to achieve convergence
   bool convStatus;    // Convergence status
   bool restart{false};

--- a/src/utils/iterativesolver/jacobi.hpp
+++ b/src/utils/iterativesolver/jacobi.hpp
@@ -13,12 +13,10 @@
 #include "iterativesolver.hpp"
 
 // The jacobi derives from the iterativesolver class
-template <class C>
-class Jacobi : public IterativeSolver<C> {
-  using LinearFunction = void(C::*) (IdefixArray3D<real> in, IdefixArray3D<real> out);
-
+template <class T>
+class Jacobi : public IterativeSolver<T> {
  public:
-  Jacobi(C *parent, LinearFunction func, real error, int maxIter, real step,
+  Jacobi(T &op, real error, int maxIter, real step,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
@@ -29,15 +27,15 @@ class Jacobi : public IterativeSolver<C> {
   real dt;
 };
 
-template <class C>
-Jacobi<C>::Jacobi(C *p, LinearFunction f, real error, int maxIter, real step,
+template <class T>
+Jacobi<T>::Jacobi(T &op, real error, int maxIter, real step,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
-            IterativeSolver<C>(p, f, error, maxIter, ntot, beg, end), dt(step) {
+            IterativeSolver<T>(op, error, maxIter, ntot, beg, end), dt(step) {
               // do nothing
             }
 
-template <class C>
-int Jacobi<C>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
+template <class T>
+int Jacobi<T>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
   idfx::pushRegion("Jacobi::Solve");
   this->solution = guess;
   this->rhs = rhs;
@@ -61,8 +59,8 @@ int Jacobi<C>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
   return(n);
 }
 
-template <class C>
-void Jacobi<C>::PerformIter() {
+template <class T>
+void Jacobi<T>::PerformIter() {
   idfx::pushRegion("Jacobi::PerformIter");
 
   // Loading needed attributes
@@ -93,8 +91,8 @@ void Jacobi<C>::PerformIter() {
   idfx::popRegion();
 }
 
-template <class C>
-void Jacobi<C>::ShowConfig() {
+template <class T>
+void Jacobi<T>::ShowConfig() {
   idfx::cout << "Jacobi: TargetError: " << this->targetError << std::endl;
   idfx::cout << "Jacobi: Maximum iterations: " << this->maxiter << std::endl;
   idfx::cout << "Jacobi: step: " << this->dt << std::endl;

--- a/src/utils/iterativesolver/minres.hpp
+++ b/src/utils/iterativesolver/minres.hpp
@@ -13,12 +13,11 @@
 #include "iterativesolver.hpp"
 
 // The conjugate gradient derives from the iterativesolver class
-template <class C>
-class Minres : public IterativeSolver<C> {
-  using LinearFunction = void(C::*) (IdefixArray3D<real> in, IdefixArray3D<real> out);
+template <class T>
+class Minres : public IterativeSolver<T> {
 
  public:
-  Minres(C *parent, LinearFunction func, real error, int maxIter,
+  Minres(T &op, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
@@ -45,10 +44,10 @@ class Minres : public IterativeSolver<C> {
   IdefixArray3D<real> work3; // work array
 };
 
-template <class C>
-Minres<C>::Minres(C *p, LinearFunction f, real error, int maxiter,
+template <class T>
+Minres<T>::Minres(T &op, real error, int maxiter,
             std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
-            IterativeSolver<C>(p, f, error, maxiter, ntot, beg, end) {
+            IterativeSolver<T>(op, error, maxiter, ntot, beg, end) {
   // MINRES scalars initialisation
   this->alpha = 1.0;
   this->beta = 1.0;
@@ -76,8 +75,8 @@ Minres<C>::Minres(C *p, LinearFunction f, real error, int maxiter,
                                                 this->ntot[IDIR]);
 }
 
-template <class C>
-int Minres<C>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
+template <class T>
+int Minres<T>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
   idfx::pushRegion("Minres::Solve");
   this->solution = guess;
   this->rhs = rhs;
@@ -107,8 +106,8 @@ int Minres<C>::Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs) {
   return(n);
 }
 
-template <class C>
-void Minres<C>::InitSolver() {
+template <class T>
+void Minres<T>::InitSolver() {
   idfx::pushRegion("Minres::InitSolver");
   // Residual initialisation
   this->SetRes();
@@ -121,8 +120,8 @@ void Minres<C>::InitSolver() {
   idfx::popRegion();
 }
 
-template <class C>
-void Minres<C>::PerformIter() {
+template <class T>
+void Minres<T>::PerformIter() {
   idfx::pushRegion("Minres::PerformIter");
 
   // Loading needed attributes
@@ -215,8 +214,8 @@ void Minres<C>::PerformIter() {
 
 
 
-template <class C>
-void Minres<C>::ShowConfig() {
+template <class T>
+void Minres<T>::ShowConfig() {
   idfx::pushRegion("Minres::ShowConfig");
   idfx::cout << "Minres: TargetError: " << this->targetError << std::endl;
   idfx::cout << "Minres: Maximum iterations: " << this->maxiter << std::endl;

--- a/src/utils/iterativesolver/minres.hpp
+++ b/src/utils/iterativesolver/minres.hpp
@@ -15,7 +15,6 @@
 // The conjugate gradient derives from the iterativesolver class
 template <class T>
 class Minres : public IterativeSolver<T> {
-
  public:
   Minres(T &op, real error, int maxIter,
            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
@@ -113,7 +112,7 @@ void Minres<T>::InitSolver() {
   this->SetRes();
 
   Kokkos::deep_copy(this->p0, this->res); // (Re)setting reference residual
-  (this->parent->*(this->myFunc))(this->p0, this->s0); // (Re)setting associated laplacian
+  this->linearOperator(this->p0, this->s0); // (Re)setting associated laplacian
   //Kokkos::deep_copy(this->p1, this->p0);
   //Kokkos::deep_copy(this->s1, this->s0);
 
@@ -172,7 +171,7 @@ void Minres<T>::PerformIter() {
   if(this->currentError/this->previousError>0.999) {
     this->firstStep = true;
     Kokkos::deep_copy(p0,r);
-    (this->parent->*(this->myFunc))(this->p0, this->s0);
+    this->linearOperator(this->p0, this->s0);
     idfx::cout << "Reset" << std::endl;
     idfx::popRegion();
     return;
@@ -181,7 +180,7 @@ void Minres<T>::PerformIter() {
   this->previousError = this->currentError;
   Kokkos::deep_copy(p0, s1);
 
-  (this->parent->*(this->myFunc))(s1, s0);
+  this->linearOperator(s1, s0);
 
   real beta1 = this->ComputeDotProduct(s0,s1) / this->ComputeDotProduct(s1,s1);
 


### PR DESCRIPTION
This MR improves the self-gravity implementation. It proposes:
- a faster implementation of the laplacian operator (by pre-computing the coefficient) that leads to a 50% faster self-gravity field computation
- a refactor of the iterativeSolver class that now takes a functor as an input, simplifying its reusability.
- SelfGravity has been refactored accordingly so that the Laplacian operator is now given as a separate functor to iterativeSolver
- The contribution of dust grains mass to the self-gravitating field has been added.