### PR TITLE
VTK slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passive tracers (!341)
 - Planet module (planet migration, planet-planet integration) (!278)
 - Custom equation of states (#185)
+- Sliced VTK files (beta version) (#195)
 - Check that the MPI library is GPU-aware when using a GPU backend (!262)
 - An optional user-defined Setup destructor can now be defined (!260)
 - performance improvement on CPUs by cleaning loops and rewriting EMF reconstruction (!281)

--- a/doc/source/modules/braginskii.rst
+++ b/doc/source/modules/braginskii.rst
@@ -1,3 +1,5 @@
+.. _braginskiiModule:
+
 Braginskii module
 ===================
 
@@ -69,6 +71,7 @@ of the Braginskii heat flux and viscosity.
   for more details on the this super time-stepping scheme.
 
 .. _braginskiiParameterSection:
+
 Main parameters of the module
 -----------------------------
 

--- a/doc/source/programmingguide.rst
+++ b/doc/source/programmingguide.rst
@@ -567,10 +567,10 @@ by setting the environement variable ``KOKKOS_TOOLS_LIBS`` to the tool path, for
   export KOKKOS_TOOLS_LIBS=<kokkos-tools-bin>/profiling/space-time-stack/libkp_space_time_stack.so
 
 
-.. _defensiveProgramming::
+.. _defensiveProgramming:
 
 Defensive Programming
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 ``idefix.hpp`` defines useful function-like macros to program defensively and create
 informative error messages and warnings.

--- a/doc/source/reference/idefix.ini.rst
+++ b/doc/source/reference/idefix.ini.rst
@@ -382,6 +382,17 @@ This section describes the outputs *Idefix* produces. For more details about eac
 | vtk_dir        | string                  | | directory for vtk file outputs. Default to "./"                                                |
 |                |                         | | The directory is automatically created if it does not exist.                                   |
 +----------------+-------------------------+--------------------------------------------------------------------------------------------------+
+| vtk_sliceN     | float, int, float,      | | Create VTK files that contain a slice (cut or average) of the full domain.                     |
+|                | string                  | | the "N" of the entry name is an integer that identify each slice, starting from n=1            |
+|                |                         | | 1st parameter: Time interval between each slice vtk file                                       |
+|                |                         | | 2nd parameter: plane of the slice. 0=(x2,x3) slice, 1=(x1,x3), 2=(x1,x2)                       |
+|                |                         | | 3rd parameter: localisation of the slice (when the slice is an average, this parameter only    |
+|                |                         | |                affect the localisation of the slice in the produced vtk file                   |
+|                |                         | | 4th parameter: slice type. Can be "cut" (for a slice of the full domain) or "average" (for an  |
+|                |                         | | average along the direction given by the second parameter). NB: "average" performs a naive     |
+|                |                         | | point average, without any consideration on the cell volumes/areas.                            |
+|                |                         | | NB2: this feature is in beta, and sometimes fail with some MPI implementations.                |
++----------------+-------------------------+--------------------------------------------------------------------------------------------------+
 | xdmf           | float                   | | Time interval between xdmf outputs, in code units (requires Idefix to be configured with HDF5) |
 |                |                         | | If negative, periodic xdmf outputs are disabled.                                               |
 +----------------+-------------------------+--------------------------------------------------------------------------------------------------+

--- a/pytools/idfx_test.py
+++ b/pytools/idfx_test.py
@@ -279,7 +279,7 @@ class idfxTest:
     if os.path.exists(os.path.join('python', 'testidefix.py')):
       os.chdir("python")
       comm = [sys.executable, "testidefix.py"]
-      if not self.plot:
+      if self.noplot:
         comm.append("-noplot")
 
       print(bcolors.OKCYAN+"Running standard test...")

--- a/src/dataBlock/dataBlock.cpp
+++ b/src/dataBlock/dataBlock.cpp
@@ -97,6 +97,9 @@ DataBlock::DataBlock(Grid &grid, Input &input) {
   dmu = IdefixArray1D<real>("DataBlock_dmu",np_tot[JDIR]);
 #endif
 
+  // Initialize our sub-domain
+  this->ExtractSubdomain();
+
   // Initialize the geometry
   this->MakeGeometry();
 
@@ -110,7 +113,7 @@ DataBlock::DataBlock(Grid &grid, Input &input) {
   this->dump = std::make_unique<Dump>(input, this);
 
   // Initialize the VTK object
-  this->vtk = std::make_unique<Vtk>(input, this);
+  this->vtk = std::make_unique<Vtk>(this, "data");
 
   // Init XDMF objects for HDF5 outputs
   #ifdef WITH_HDF5
@@ -151,6 +154,94 @@ DataBlock::DataBlock(Grid &grid, Input &input) {
   dump->RegisterVariable(&t, "time");
   dump->RegisterVariable(&dt, "dt");
 
+  idfx::popRegion();
+}
+
+/**
+ * @brief Construct a new Data Block as a subgrid
+ *
+ * @param subgrid : subgrid from which the local datablock should be extracted from
+ */
+DataBlock::DataBlock(SubGrid *subgrid) {
+  idfx::pushRegion("DataBlock:DataBlock(SubGrid)");
+  Grid *grid = subgrid->parentGrid;
+  this->mygrid = subgrid->grid.get();
+
+  // Make a local copy of the grid for future usage.
+  GridHost gridHost(*grid);
+  gridHost.SyncFromDevice();
+
+
+  // Get the number of points from the parent grid object
+  for(int dir = 0 ; dir < 3 ; dir++) {
+    nghost[dir] = grid->nghost[dir];
+    // Domain decomposition: decompose the full domain size in grid by the number of processes
+    // in that direction
+    np_int[dir] = grid->np_int[dir]/grid->nproc[dir];
+    np_tot[dir] = np_int[dir]+2*nghost[dir];
+
+    // Boundary conditions
+    if (grid->xproc[dir]==0) {
+      lbound[dir] = grid->lbound[dir];
+      if(lbound[dir]==axis) this->haveAxis = true;
+    } else {
+      lbound[dir] = internal;
+    }
+
+    if (grid->xproc[dir] == grid->nproc[dir]-1) {
+      rbound[dir] = grid->rbound[dir];
+      if(rbound[dir]==axis) this->haveAxis = true;
+    } else {
+      rbound[dir] = internal;
+    }
+
+    beg[dir] = grid->nghost[dir];
+    end[dir] = grid->nghost[dir]+np_int[dir];
+
+    // Where does this datablock starts and end in the grid?
+    // This assumes even distribution of points between procs
+    gbeg[dir] = grid->nghost[dir] + grid->xproc[dir]*np_int[dir];
+    gend[dir] = grid->nghost[dir] + (grid->xproc[dir]+1)*np_int[dir];
+
+    // Local start and end of current datablock
+    xbeg[dir] = gridHost.xl[dir](gbeg[dir]);
+    xend[dir] = gridHost.xr[dir](gend[dir]-1);
+  }
+
+  // Next we erase the info the slice direction
+  int refdir = subgrid->direction;
+  nghost[refdir] = 0;
+  np_int[refdir] = 1;
+  np_tot[refdir] = 1;
+  beg[refdir] = 0;
+  end[refdir] = 1;
+  gbeg[refdir] = subgrid->index;
+  gend[refdir] = subgrid->index+1;
+  xbeg[refdir] = gridHost.x[refdir](subgrid->index);
+  xend[refdir] = gridHost.x[refdir](subgrid->index);
+
+  // Allocate the required fields (only a limited set for a datablock from a subgrid)
+  std::string label;
+  for(int dir = 0 ; dir < 3 ; dir++) {
+    label = "DataBlock_x" + std::to_string(dir);
+    x[dir] = IdefixArray1D<real>(label, np_tot[dir]);
+
+    label = "DataBlock_xr" + std::to_string(dir);
+    xr[dir] = IdefixArray1D<real>(label,np_tot[dir]);
+
+    label = "DataBlock_xl" + std::to_string(dir);
+    xl[dir] = IdefixArray1D<real>(label,np_tot[dir]);
+
+    label = "DataBlock_dx" + std::to_string(dir);
+    dx[dir] = IdefixArray1D<real>(label,np_tot[dir]);
+  }
+
+  // Initialize our sub-domain
+  this->ExtractSubdomain();
+
+  // Reset gbeg/gend so that they don't refer anymore to the parent grid
+  gbeg[refdir] = 0;
+  gend[refdir] = 1;
   idfx::popRegion();
 }
 

--- a/src/dataBlock/dataBlock.cpp
+++ b/src/dataBlock/dataBlock.cpp
@@ -26,18 +26,6 @@ DataBlock::DataBlock(Grid &grid, Input &input) {
   GridHost gridHost(grid);
   gridHost.SyncFromDevice();
 
-  nghost = std::vector<int>(3);
-  np_int = std::vector<int>(3);
-  np_tot = std::vector<int>(3);
-  lbound = std::vector<BoundaryType>(3);
-  rbound = std::vector<BoundaryType>(3);
-  beg = std::vector<int>(3);
-  end = std::vector<int>(3);
-  gbeg = std::vector<int>(3);
-  gend = std::vector<int>(3);
-
-  xbeg = std::vector<real>(3);
-  xend = std::vector<real>(3);
 
   // Get the number of points from the parent grid object
   for(int dir = 0 ; dir < 3 ; dir++) {
@@ -79,23 +67,23 @@ DataBlock::DataBlock(Grid &grid, Input &input) {
   std::string label;
   for(int dir = 0 ; dir < 3 ; dir++) {
     label = "DataBlock_x" + std::to_string(dir);
-    x.push_back(IdefixArray1D<real>(label, np_tot[dir]));
+    x[dir] = IdefixArray1D<real>(label, np_tot[dir]);
 
     label = "DataBlock_xr" + std::to_string(dir);
-    xr.push_back(IdefixArray1D<real>(label,np_tot[dir]));
+    xr[dir] = IdefixArray1D<real>(label,np_tot[dir]);
 
     label = "DataBlock_xl" + std::to_string(dir);
-    xl.push_back(IdefixArray1D<real>(label,np_tot[dir]));
+    xl[dir] = IdefixArray1D<real>(label,np_tot[dir]);
 
     label = "DataBlock_dx" + std::to_string(dir);
-    dx.push_back(IdefixArray1D<real>(label,np_tot[dir]));
+    dx[dir] = IdefixArray1D<real>(label,np_tot[dir]);
 
     label = "DataBlock_xgc" + std::to_string(dir);
-    xgc.push_back(IdefixArray1D<real>(label,np_tot[dir]));
+    xgc[dir] = IdefixArray1D<real>(label,np_tot[dir]);
 
     label = "DataBlock_A" + std::to_string(dir);
-    A.push_back(IdefixArray3D<real>(label,
-                                 np_tot[KDIR]+KOFFSET, np_tot[JDIR]+JOFFSET, np_tot[IDIR]+IOFFSET));
+    A[dir] = IdefixArray3D<real>(label,
+                                 np_tot[KDIR]+KOFFSET, np_tot[JDIR]+JOFFSET, np_tot[IDIR]+IOFFSET);
   }
 
   dV = IdefixArray3D<real>("DataBlock_dV",np_tot[KDIR],np_tot[JDIR],np_tot[IDIR]);

--- a/src/dataBlock/dataBlock.cpp
+++ b/src/dataBlock/dataBlock.cpp
@@ -113,7 +113,7 @@ DataBlock::DataBlock(Grid &grid, Input &input) {
   this->dump = std::make_unique<Dump>(input, this);
 
   // Initialize the VTK object
-  this->vtk = std::make_unique<Vtk>(this, "data");
+  this->vtk = std::make_unique<Vtk>(input, this, "data");
 
   // Init XDMF objects for HDF5 outputs
   #ifdef WITH_HDF5

--- a/src/dataBlock/dataBlock.hpp
+++ b/src/dataBlock/dataBlock.hpp
@@ -17,6 +17,7 @@
 #include "grid.hpp"
 #include "gridHost.hpp"
 #include "output.hpp"
+#include "planetarySystem.hpp"
 #include "gravity.hpp"
 #include "stateContainer.hpp"
 
@@ -39,6 +40,7 @@ class Gravity;
 class PlanetarySystem;
 template<typename Phys>
 class Fluid;
+class SubGrid;
 
 // Forward class hydro declaration
 #include "physics.hpp"
@@ -120,8 +122,10 @@ class DataBlock {
 
 
   DataBlock(Grid &, Input &);     ///< init from a Grid object
+  explicit DataBlock(SubGrid *);           ///< init a minimal datablock for a subgrid
 
-  void MakeGeometry();                ///< Compute geometrical terms
+  void ExtractSubdomain();        ///< initialise datablock sub-domain according to domain decomp.
+  void MakeGeometry();            ///< Compute geometrical terms
   void DumpToFile(std::string);   ///< Dump current datablock to a file for inspection
   void Validate();                ///< error out early in case problems are found in IC
   int CheckNan();                 ///< Return the number of cells which have Nans

--- a/src/dataBlock/dataBlock.hpp
+++ b/src/dataBlock/dataBlock.hpp
@@ -50,11 +50,11 @@ using StepFunc = void (*) (DataBlock &, const real t, const real dt);
 class DataBlock {
  public:
   // Local grid information
-  std::vector<IdefixArray1D<real>> x;    ///< geometrical central points
-  std::vector<IdefixArray1D<real>> xr;   ///< cell right interface
-  std::vector<IdefixArray1D<real>> xl;   ///< cell left interface
-  std::vector<IdefixArray1D<real>> dx;   ///< cell width
-  std::vector<IdefixArray1D<real>> xgc;  ///< cell geometrical cell center
+  std::array<IdefixArray1D<real>,3> x;    ///< geometrical central points
+  std::array<IdefixArray1D<real>,3> xr;   ///< cell right interface
+  std::array<IdefixArray1D<real>,3> xl;   ///< cell left interface
+  std::array<IdefixArray1D<real>,3> dx;   ///< cell width
+  std::array<IdefixArray1D<real>,3> xgc;  ///< cell geometrical cell center
   IdefixArray1D<real> rt;      ///< In spherical coordinates, gives $\tilde{r}$
   IdefixArray1D<real> sinx2m;  ///< In spherical coordinates,
                                ///< gives sin(th) at a j-1/2 interface
@@ -65,23 +65,23 @@ class DataBlock {
   IdefixArray1D<real> dmu;     ///< In spherical coordinates,
                                ///< gives the $\theta$ volume = fabs(cos(th_m) - cos(th_p))
 
-  std::vector<IdefixArray2D<int>> coarseningLevel; ///< Grid coarsening levels
+  std::array<IdefixArray2D<int>,3> coarseningLevel; ///< Grid coarsening levels
                                                   ///< (only defined when coarsening
                                                   ///< is enabled)
-  std::vector<bool> coarseningDirection;  ///< whether a coarsening is used in each direction
+  std::array<bool,3> coarseningDirection;  ///< whether a coarsening is used in each direction
 
-  std::vector<real> xbeg;             ///< Beginning of active domain in datablock
-  std::vector<real> xend;             ///< End of active domain in datablock
+  std::array<real,3> xbeg;             ///< Beginning of active domain in datablock
+  std::array<real,3> xend;             ///< End of active domain in datablock
 
   IdefixArray3D<real> dV;                ///< cell volume
-  std::vector<IdefixArray3D<real>> A;    ///< cell left interface area
+  std::array<IdefixArray3D<real>,3> A;    ///< cell left interface area
 
-  std::vector<int> np_tot;        ///< total number of grid points in datablock
-  std::vector<int> np_int;        ///< active number of grid points in datablock (excl. ghost cells)
+  std::array<int,3> np_tot;     ///< total number of grid points in datablock
+  std::array<int,3> np_int;     ///< active number of grid points in datablock (excl. ghost cells)
 
-  std::vector<int> nghost;               ///< number of ghost cells at each boundary
-  std::vector<BoundaryType> lbound;      ///< Boundary condition to the left
-  std::vector<BoundaryType> rbound;      ///< Boundary condition to the right
+  std::array<int,3> nghost;               ///< number of ghost cells at each boundary
+  std::array<BoundaryType,3> lbound;      ///< Boundary condition to the left
+  std::array<BoundaryType,3> rbound;      ///< Boundary condition to the right
 
   bool haveAxis{false};       ///< DataBlock contains points on the axis and a special treatment
                                ///< has been required for these.
@@ -93,11 +93,11 @@ class DataBlock {
 
 
 
-  std::vector<int> beg;       ///< First local index of the active domain
-  std::vector<int> end;       ///< Last local index of the active domain+1
+  std::array<int,3> beg;       ///< First local index of the active domain
+  std::array<int,3> end;       ///< Last local index of the active domain+1
 
-  std::vector<int> gbeg;      ///< First global index of the active domain of this datablock
-  std::vector<int> gend;      ///< Last global index of the active domain of this datablock
+  std::array<int,3> gbeg;      ///< First global index of the active domain of this datablock
+  std::array<int,3> gend;      ///< Last global index of the active domain of this datablock
 
   real dt;                     ///< Current timestep
   real t;                      ///< Current time

--- a/src/dataBlock/dataBlock.hpp
+++ b/src/dataBlock/dataBlock.hpp
@@ -16,7 +16,6 @@
 #include "idefix.hpp"
 #include "grid.hpp"
 #include "gridHost.hpp"
-#include "output.hpp"
 #include "planetarySystem.hpp"
 #include "gravity.hpp"
 #include "stateContainer.hpp"
@@ -41,6 +40,8 @@ class PlanetarySystem;
 template<typename Phys>
 class Fluid;
 class SubGrid;
+class Vtk;
+class Dump;
 
 // Forward class hydro declaration
 #include "physics.hpp"

--- a/src/dataBlock/dataBlockHost.cpp
+++ b/src/dataBlock/dataBlockHost.cpp
@@ -20,11 +20,11 @@ DataBlockHost::DataBlockHost(DataBlock& datain) {
 
   // Create mirrors (should be mirror_view)
   for(int dir = 0 ; dir < 3 ; dir++) {
-    x.push_back(Kokkos::create_mirror_view(data->x[dir]));
-    xr.push_back(Kokkos::create_mirror_view(data->xr[dir]));
-    xl.push_back(Kokkos::create_mirror_view(data->xl[dir]));
-    dx.push_back(Kokkos::create_mirror_view(data->dx[dir]));
-    A.push_back(Kokkos::create_mirror_view(data->A[dir]));
+    x[dir] = Kokkos::create_mirror_view(data->x[dir]);
+    xr[dir] = Kokkos::create_mirror_view(data->xr[dir]);
+    xl[dir] = Kokkos::create_mirror_view(data->xl[dir]);
+    dx[dir] = Kokkos::create_mirror_view(data->dx[dir]);
+    A[dir] = Kokkos::create_mirror_view(data->A[dir]);
   }
 
   np_tot = data->np_tot;
@@ -74,7 +74,6 @@ DataBlockHost::DataBlockHost(DataBlock& datain) {
   if(data->haveGridCoarsening) {
     this->haveGridCoarsening = data->haveGridCoarsening;
     this->coarseningDirection = data->coarseningDirection;
-    this->coarseningLevel = std::vector<IdefixArray2D<int>::HostMirror>(3);
     for(int dir = 0 ; dir < 3 ; dir++) {
       if(coarseningDirection[dir]) {
         coarseningLevel[dir] = Kokkos::create_mirror_view(data->coarseningLevel[dir]);

--- a/src/dataBlock/dataBlockHost.hpp
+++ b/src/dataBlock/dataBlockHost.hpp
@@ -25,13 +25,13 @@
 class DataBlockHost {
  public:
   // Local grid information
-  std::vector<IdefixArray1D<real>::HostMirror> x;   ///< geometrical central points
-  std::vector<IdefixArray1D<real>::HostMirror> xr;  ///< cell right interface
-  std::vector<IdefixArray1D<real>::HostMirror> xl;  ///< cell left interface
-  std::vector<IdefixArray1D<real>::HostMirror> dx;  ///< cell width
+  std::array<IdefixArray1D<real>::HostMirror,3> x;   ///< geometrical central points
+  std::array<IdefixArray1D<real>::HostMirror,3> xr;  ///< cell right interface
+  std::array<IdefixArray1D<real>::HostMirror,3> xl;  ///< cell left interface
+  std::array<IdefixArray1D<real>::HostMirror,3> dx;  ///< cell width
 
   IdefixArray3D<real>::HostMirror dV;     ///< cell volume
-  std::vector<IdefixArray3D<real>::HostMirror> A;   ///< cell right interface area
+  std::array<IdefixArray3D<real>::HostMirror,3> A;   ///< cell right interface area
 
   IdefixArray4D<real>::HostMirror Vc;     ///< Main cell-centered primitive variables index
 
@@ -51,29 +51,29 @@ class DataBlockHost {
   IdefixArray4D<real>::HostMirror Uc;     ///< Main cell-centered conservative variables
   IdefixArray3D<real>::HostMirror InvDt;  ///< Inverse of maximum timestep in each cell
 
-  std::vector<IdefixArray2D<int>::HostMirror> coarseningLevel; ///< Grid coarsening level
+  std::array<IdefixArray2D<int>::HostMirror,3> coarseningLevel; ///< Grid coarsening level
                                                      ///< (only defined when coarsening
                                                      ///< is enabled)
 
-  std::vector<bool> coarseningDirection;         ///< whether a coarsening is used in each direction
+  std::array<bool,3> coarseningDirection;       ///< whether a coarsening is used in each direction
 
 
-  std::vector<real> xbeg;                        ///> Beginning of dataBlock
-  std::vector<real> xend;                        ///> End of dataBlock
+  std::array<real,3> xbeg;                      ///> Beginning of dataBlock
+  std::array<real,3> xend;                      ///> End of dataBlock
 
-  std::vector<int> np_tot;                  ///< total number of grid points
-  std::vector<int> np_int;                  ///< internal number of grid points
+  std::array<int,3> np_tot;                  ///< total number of grid points
+  std::array<int,3> np_int;                  ///< internal number of grid points
 
-  std::vector<int> nghost;                  ///< number of ghost cells
+  std::array<int,3> nghost;                  ///< number of ghost cells
 
-  std::vector<BoundaryType> lbound;           ///< Boundary condition to the left
-  std::vector<BoundaryType> rbound;           ///< Boundary condition to the right
+  std::array<BoundaryType,3> lbound;           ///< Boundary condition to the left
+  std::array<BoundaryType,3> rbound;           ///< Boundary condition to the right
 
-  std::vector<int> beg;                       ///< Begining of internal indices
-  std::vector<int> end;                       ///< End of internal indices
+  std::array<int,3> beg;                       ///< Begining of internal indices
+  std::array<int,3> end;                       ///< End of internal indices
 
-  std::vector<int> gbeg;                      ///< Begining of local block in the grid (internal)
-  std::vector<int> gend;                      ///< End of local block in the grid (internal)
+  std::array<int,3> gbeg;                      ///< Begining of local block in the grid (internal)
+  std::array<int,3> gend;                      ///< End of local block in the grid (internal)
 
   explicit DataBlockHost(DataBlock &);        ///< Constructor from a device datablock
                                               ///< (NB: does not sync any data)

--- a/src/dataBlock/fargo.hpp
+++ b/src/dataBlock/fargo.hpp
@@ -64,9 +64,9 @@ class Fargo {
   Mpi mpi;                      // Fargo-specific MPI layer
 #endif
 
-  std::vector<int> beg;
-  std::vector<int> end;
-  std::vector<int> nghost;
+  std::array<int,3> beg;
+  std::array<int,3> end;
+  std::array<int,3> nghost;
   int maxShift;                         //< maximum number of cells along which we plan to shift.
   real dtMax{0};                        //< Maximum allowable dt for a given Fargo velocity
                                         //< when domain decomposition is enabled

--- a/src/dataBlock/makeGeometry.cpp
+++ b/src/dataBlock/makeGeometry.cpp
@@ -43,7 +43,6 @@ void DataBlock::MakeGeometry() {
   if(mygrid->haveGridCoarsening != GridCoarsening::disabled) {
     this->haveGridCoarsening = mygrid->haveGridCoarsening;
     this->coarseningDirection = mygrid->coarseningDirection;
-    this->coarseningLevel = std::vector<IdefixArray2D<int>>(3);
 
     for(int dir = 0 ; dir < 3 ; dir++) {
       if(coarseningDirection[dir]) {

--- a/src/dataBlock/makeGeometry.cpp
+++ b/src/dataBlock/makeGeometry.cpp
@@ -16,28 +16,6 @@
 void DataBlock::MakeGeometry() {
   idfx::pushRegion("DataBlock::MakeGeometry()");
 
-  // Copy the relevant part of the coordinate system to the datablock
-  for(int dir = 0 ; dir < 3 ; dir++) {
-    int offset=gbeg[dir]-beg[dir];
-
-    IdefixArray1D<real> x_input = mygrid->x[dir];
-    IdefixArray1D<real> x_output= x[dir];
-    IdefixArray1D<real> xr_input = mygrid->xr[dir];
-    IdefixArray1D<real> xr_output= xr[dir];
-    IdefixArray1D<real> xl_input = mygrid->xl[dir];
-    IdefixArray1D<real> xl_output= xl[dir];
-    IdefixArray1D<real> dx_input = mygrid->dx[dir];
-    IdefixArray1D<real> dx_output= dx[dir];
-
-    idefix_for("coordinates",0,np_tot[dir],
-      KOKKOS_LAMBDA (int i) {
-        x_output(i)  = x_input(i+offset);
-        xr_output(i) = xr_input(i+offset);
-        xl_output(i) = xl_input(i+offset);
-        dx_output(i) = dx_input(i+offset);
-      }
-    );
-  }
 
   // Initialize grid coarsening if needed
   if(mygrid->haveGridCoarsening != GridCoarsening::disabled) {
@@ -234,6 +212,34 @@ void DataBlock::MakeGeometry() {
   #endif
     }
   );
+
+  idfx::popRegion();
+}
+
+void DataBlock::ExtractSubdomain() {
+  idfx::pushRegion("DataBlock::ExtractSubdomain");
+  // Copy the relevant part of the coordinate system to the datablock
+  for(int dir = 0 ; dir < 3 ; dir++) {
+    int offset=gbeg[dir]-beg[dir];
+
+    IdefixArray1D<real> x_input = mygrid->x[dir];
+    IdefixArray1D<real> x_output= x[dir];
+    IdefixArray1D<real> xr_input = mygrid->xr[dir];
+    IdefixArray1D<real> xr_output= xr[dir];
+    IdefixArray1D<real> xl_input = mygrid->xl[dir];
+    IdefixArray1D<real> xl_output= xl[dir];
+    IdefixArray1D<real> dx_input = mygrid->dx[dir];
+    IdefixArray1D<real> dx_output= dx[dir];
+
+    idefix_for("coordinates",0,np_tot[dir],
+      KOKKOS_LAMBDA (int i) {
+        x_output(i)  = x_input(i+offset);
+        xr_output(i) = xr_input(i+offset);
+        xl_output(i) = xl_input(i+offset);
+        dx_output(i) = dx_input(i+offset);
+      }
+    );
+  }
 
   idfx::popRegion();
 }

--- a/src/fluid/fluid.hpp
+++ b/src/fluid/fluid.hpp
@@ -14,7 +14,6 @@
 
 #include "idefix.hpp"
 #include "grid.hpp"
-#include "output.hpp"
 #include "fluid_defs.hpp"
 #include "thermalDiffusion.hpp"
 #include "bragThermalDiffusion.hpp"

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -32,8 +32,8 @@ Laplacian::Laplacian(DataBlock *datain, std::array<LaplacianBoundaryType,3> left
   this->sinx2 = data->sinx2;
   this->dV = data->dV;
   this->A = data->A;
-  this->loffset = std::vector<int>(3,0);
-  this->roffset = std::vector<int>(3,0);
+  this->loffset = {0,0,0};
+  this->roffset = {0,0,0};
 
   this->lbound = leftBound;
   this->rbound = rightBound;

--- a/src/gravity/laplacian.hpp
+++ b/src/gravity/laplacian.hpp
@@ -50,25 +50,25 @@ class Laplacian {
   UserDefBoundaryFunc userDefBoundaryFunc{NULL};
 
   // Local potential array size
-  std::vector<int> np_tot;
-  std::vector<int> np_int;
+  std::array<int,3> np_tot;
+  std::array<int,3> np_int;
 
-  std::vector<int> nghost;
-  std::vector<int> beg;
-  std::vector<int> end;
+  std::array<int,3> nghost;
+  std::array<int,3> beg;
+  std::array<int,3> end;
 
   // offset in the left and right direction between selfgravity grid and datablock grid
-  std::vector<int> loffset;
-  std::vector<int> roffset;
+  std::array<int,3> loffset;
+  std::array<int,3> roffset;
 
   // Grid for self-gravity solver (note that this grid may extend the grid of the current datablock)
-  std::vector<IdefixArray1D<real>> x;    ///< geometrical central points
-  std::vector<IdefixArray1D<real>> dx;   ///< cell width
+  std::array<IdefixArray1D<real>,3> x;    ///< geometrical central points
+  std::array<IdefixArray1D<real>,3> dx;   ///< cell width
 
   IdefixArray1D<real> sinx2;            ///< sinx2 (only in spherical)
 
   IdefixArray3D<real> dV;                ///< cell volume
-  std::vector<IdefixArray3D<real>> A;    ///< cell left interface area
+  std::array<IdefixArray3D<real>,3> A;    ///< cell left interface area
 
   bool isPeriodic; // Periodicity status of the density distribution
   std::array<LaplacianBoundaryType,3> lbound;  // Boundary condition to the left

--- a/src/gravity/selfGravity.hpp
+++ b/src/gravity/selfGravity.hpp
@@ -67,7 +67,7 @@ class SelfGravity {
   real dt;  // CFL timestep
 
   // Local potential array size
-  std::vector<int> np_tot;
+  std::array<int,3> np_tot;
 
   std::array<Laplacian::LaplacianBoundaryType,3> lbound;  // Boundary condition to the left
   std::array<Laplacian::LaplacianBoundaryType,3> rbound;  // Boundary condition to the right

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -440,5 +440,4 @@ void Grid::SliceMe(SubGrid *subgrid) {
     nproc[dir] = 1;
     xproc[dir] = 0;
   #endif
-  idfx::cout << "Comm: " << this->CartComm;
 }

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -61,6 +61,8 @@ class Grid {
 
   void ShowConfig();
 
+  void SliceMe(SubGrid *);       ///< Slice this grid according to the subgrid (internal function)
+
   Grid() = default;
 
  private:
@@ -75,10 +77,9 @@ class Grid {
  */
 class SubGrid {
  public:
-  enum class Type {Slice, Average};
-
-  SubGrid(Grid * grid, Type type, int d, real x0):
+  SubGrid(Grid * grid, SliceType type, int d, real x0):
           parentGrid(grid), type(type), direction(d) {
+            idfx::pushRegion("SubGrid::SubGrid()");
             // Find the index of the current subgrid.
             auto x = Kokkos::create_mirror_view(parentGrid->x[direction]);
             Kokkos::deep_copy(x,parentGrid->x[direction]);
@@ -106,12 +107,13 @@ class SubGrid {
             this->x0 = x(iref);
 
             this->grid = std::make_unique<Grid>(this);
+            idfx::popRegion();
   }
 
-  const Grid *parentGrid;
+  Grid *parentGrid;
   std::unique_ptr<Grid> grid;
 
-  const Type type;
+  const SliceType type;
   const int direction;
   real x0;   ///< Cell center coordinate of the slice/average
   int index; ///< index in parent grid of the slice/average

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -8,6 +8,7 @@
 #ifndef GRID_HPP_
 #define GRID_HPP_
 #include <vector>
+#include <memory>
 #include "idefix.hpp"
 #include "input.hpp"
 
@@ -19,33 +20,34 @@
 /// the arrays of a Grid are on the device. If a Host access is needed,
 /// it is recommended to use a GridHost instance from this Grid, and sync it.
 /////////////////////////////////////////////////////////////////////////////////////////////////
+class SubGrid;    // Forward class declaration
 
 class Grid {
  public:
-  std::vector<IdefixArray1D<real>> x;    ///< geometrical central points
-  std::vector<IdefixArray1D<real>> xr;   ///< cell right interface
-  std::vector<IdefixArray1D<real>> xl;   ///< cell left interface
-  std::vector<IdefixArray1D<real>> dx;   ///< cell width
+  std::array<IdefixArray1D<real>,3> x;    ///< geometrical central points
+  std::array<IdefixArray1D<real>,3> xr;   ///< cell right interface
+  std::array<IdefixArray1D<real>,3> xl;   ///< cell left interface
+  std::array<IdefixArray1D<real>,3> dx;   ///< cell width
 
-  std::vector<real> xbeg;           ///< Beginning of grid
-  std::vector<real> xend;           ///< End of grid
+  std::array<real,3> xbeg;           ///< Beginning of grid
+  std::array<real,3> xend;           ///< End of grid
 
-  std::vector<int> np_tot;          ///< total number of grid points (including ghosts)
-  std::vector<int> np_int;          ///< internal number of grid points (excluding ghosts)
+  std::array<int,3> np_tot;          ///< total number of grid points (including ghosts)
+  std::array<int,3> np_int;          ///< internal number of grid points (excluding ghosts)
 
-  std::vector<int> nghost;          ///< number of ghost cells
-  std::vector<BoundaryType> lbound;          ///< Boundary condition to the left
-  std::vector<BoundaryType> rbound;          ///< Boundary condition to the right
+  std::array<int,3> nghost;          ///< number of ghost cells
+  std::array<BoundaryType,3> lbound;          ///< Boundary condition to the left
+  std::array<BoundaryType,3> rbound;          ///< Boundary condition to the right
 
   bool haveAxis{false};    ///< Do we require a special treatment of the axis in spherical coords?
 
 
   GridCoarsening haveGridCoarsening{GridCoarsening::disabled}; ///< Is grid coarsening enabled?
-  std::vector<bool> coarseningDirection;  ///< whether a coarsening is used in each direction
+  std::array<bool,3> coarseningDirection;  ///< whether a coarsening is used in each direction
 
   // MPI data
-  std::vector<int> nproc;           ///</< Total number of procs in each direction
-  std::vector<int> xproc;           ///</< Coordinates of current proc in the array of procs
+  std::array<int,3> nproc;           ///</< Total number of procs in each direction
+  std::array<int,3> xproc;           ///</< Coordinates of current proc in the array of procs
 
   #ifdef WITH_MPI
   MPI_Comm CartComm;                ///< Cartesian communicator for the planned domain decomposition
@@ -55,6 +57,8 @@ class Grid {
 
   // Constructor
   explicit Grid(Input &);
+  explicit Grid(SubGrid *);
+
   void ShowConfig();
 
   Grid() = default;
@@ -63,6 +67,54 @@ class Grid {
   // Check if number is a power of 2
   bool isPow2(int);
   void makeDomainDecomposition();
+};
+
+/**
+ * @brief SubGrid allows one to define a grid as a slice or averaged from another grid
+ *
+ */
+class SubGrid {
+ public:
+  enum class Type {Slice, Average};
+
+  SubGrid(Grid * grid, Type type, int d, real x0):
+          parentGrid(grid), type(type), direction(d) {
+            // Find the index of the current subgrid.
+            auto x = Kokkos::create_mirror_view(parentGrid->x[direction]);
+            Kokkos::deep_copy(x,parentGrid->x[direction]);
+            int iref = -1;
+            for(int i = 0 ; i < x.extent(0) - 1 ; i++) {
+              if(x(i+1) >= x0) {
+                if(x(i+1) - x0 > x0 - x(i) ) {
+                  // we're closer to x(i)
+                  iref = i;
+                } else {
+                  iref = i+1;
+                }
+                break;
+              }
+            }
+            if(iref < 0) {
+              std::stringstream msg;
+              msg << "Cannot generate a subgrid in direction " << d << "with x0=" << x0
+                  << "." << std::endl
+                  << "Bounds are " << x(0) << "..." << x(x.extent(0)-1) << std::endl;
+
+              IDEFIX_ERROR(msg);
+            }
+            this->index = iref;
+            this->x0 = x(iref);
+
+            this->grid = std::make_unique<Grid>(this);
+  }
+
+  const Grid *parentGrid;
+  std::unique_ptr<Grid> grid;
+
+  const Type type;
+  const int direction;
+  real x0;   ///< Cell center coordinate of the slice/average
+  int index; ///< index in parent grid of the slice/average
 };
 
 #endif // GRID_HPP_

--- a/src/gridHost.cpp
+++ b/src/gridHost.cpp
@@ -29,10 +29,6 @@ GridHost::GridHost(Grid &grid) {
   haveAxis = grid.haveAxis;
 
   // Create mirrors on host
-  x = std::vector<IdefixArray1D<real>::HostMirror> (3);
-  xr = std::vector<IdefixArray1D<real>::HostMirror> (3);
-  xl = std::vector<IdefixArray1D<real>::HostMirror> (3);
-  dx = std::vector<IdefixArray1D<real>::HostMirror> (3);
   for(int dir = 0 ; dir < 3 ; dir++) {
     x[dir] = Kokkos::create_mirror_view(grid.x[dir]);
     xr[dir] = Kokkos::create_mirror_view(grid.xr[dir]);

--- a/src/gridHost.hpp
+++ b/src/gridHost.hpp
@@ -22,20 +22,20 @@
 
 class GridHost {
  public:
-  std::vector<IdefixArray1D<real>::HostMirror> x;     ///< geometrical central points
-  std::vector<IdefixArray1D<real>::HostMirror> xr; ///< cell right interface
-  std::vector<IdefixArray1D<real>::HostMirror> xl; ///< cell left interface
-  std::vector<IdefixArray1D<real>::HostMirror> dx; ///< cell width
+  std::array<IdefixArray1D<real>::HostMirror,3> x;     ///< geometrical central points
+  std::array<IdefixArray1D<real>::HostMirror,3> xr; ///< cell right interface
+  std::array<IdefixArray1D<real>::HostMirror,3> xl; ///< cell left interface
+  std::array<IdefixArray1D<real>::HostMirror,3> dx; ///< cell width
 
-  std::vector<real> xbeg;                   ///< Beginning of grid
-  std::vector<real> xend;                   ///< End of grid
+  std::array<real,3> xbeg;                   ///< Beginning of grid
+  std::array<real,3> xend;                   ///< End of grid
 
-  std::vector<int> np_tot;                  ///< total number of grid points
-  std::vector<int> np_int;                  ///< internal number of grid points
+  std::array<int,3> np_tot;                  ///< total number of grid points
+  std::array<int,3> np_int;                  ///< internal number of grid points
 
-  std::vector<int> nghost;                  ///< number of ghost cells
-  std::vector<BoundaryType> lbound;         ///< Boundary condition to the left
-  std::vector<BoundaryType> rbound;         ///< Boundary condition to the right
+  std::array<int,3> nghost;                  ///< number of ghost cells
+  std::array<BoundaryType,3> lbound;         ///< Boundary condition to the left
+  std::array<BoundaryType,3> rbound;         ///< Boundary condition to the right
 
   bool haveAxis=false;    ///< Do we require a special treatment of the axis in spherical coords?
 

--- a/src/idefix.hpp
+++ b/src/idefix.hpp
@@ -219,6 +219,7 @@ using IdfxFileHandler = FILE*;
 // Types of boundary which can be treated
 enum BoundaryType { internal, periodic, reflective, outflow, shearingbox, axis, userdef};
 enum BoundarySide { left, right};
+enum class SliceType {Cut, Average};
 
 // Type of grid coarsening
 enum GridCoarsening{disabled,

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -1,4 +1,6 @@
 target_sources(idefix
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/slice.cpp
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/slice.hpp
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/dump.cpp
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/dump.hpp
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/output.cpp

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -7,6 +7,8 @@
 
 #include <filesystem>
 #include "output.hpp"
+#include "dataBlock.hpp"
+#include "fluid.hpp"
 #include "slice.hpp"
 
 Output::Output(Input &input, DataBlock &data) {
@@ -43,7 +45,7 @@ Output::Output(Input &input, DataBlock &data) {
       } else {
         IDEFIX_ERROR("Unknown slice type "+typeStr);
       }
-      slices.emplace_back(std::make_unique<Slice>(data, n, type, direction, x0, period));
+      slices.emplace_back(std::make_unique<Slice>(input, data, n, type, direction, x0, period));
       // Next iteration
       n++;
     }

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 #include "output.hpp"
+#include "slice.hpp"
 
 Output::Output(Input &input, DataBlock &data) {
   idfx::pushRegion("Output::Output");
@@ -21,6 +22,30 @@ Output::Output(Input &input, DataBlock &data) {
     if(vtkPeriod>=0.0) {  // backward compatibility (negative value means no file)
       vtkLast = data.t - vtkPeriod; // write something in the next CheckForWrite()
       vtkEnabled = true;
+    }
+  }
+
+  // Look for slice outputs (in the form of VTK files)
+  if(input.CheckEntry("Output","vtkSlice1")>0) {
+    sliceEnabled = true;
+    int n = 1;
+    while(input.CheckEntry("Output","vtkSlice"+std::to_string(n))>0) {
+      std::string sliceStr = "vtkSlice"+std::to_string(n);
+      real period = input.Get<real>("Output", sliceStr,0);
+      int direction = input.Get<int>("Output", sliceStr,1);
+      real x0 = input.Get<real>("Output", sliceStr, 2);
+      std::string typeStr = input.Get<std::string>("Output",sliceStr,3);
+      SliceType type;
+      if(typeStr.compare("cut")==0) {
+        type = SliceType::Cut;
+      } else if(typeStr.compare("average")==0) {
+        type = SliceType::Average;
+      } else {
+        IDEFIX_ERROR("Unknown slice type "+typeStr);
+      }
+      slices.emplace_back(std::make_unique<Slice>(data, n, type, direction, x0, period));
+      // Next iteration
+      n++;
     }
   }
 
@@ -175,6 +200,11 @@ int Output::CheckForWrites(DataBlock &data) {
     }
   }
 
+  if(sliceEnabled) {
+    for(int i = 0 ; i < slices.size() ; i++) {
+      slices[i]->CheckForWrite(data);
+    }
+  }
   // Do we need a restart dump?
   if(dumpEnabled) {
     // Dumps contain metadata about the most recent outputs of other types,

--- a/src/output/output.hpp
+++ b/src/output/output.hpp
@@ -9,6 +9,8 @@
 #define OUTPUT_OUTPUT_HPP_
 #include <string>
 #include <map>
+#include <vector>
+#include <memory>
 #include "idefix.hpp"
 #include "input.hpp"
 #include "dataBlock.hpp"
@@ -17,7 +19,10 @@
 #include "xdmf.hpp"
 #endif
 #include "dump.hpp"
+#include "slice.hpp"
 
+class Vtk;
+class Dump;
 
 using AnalysisFunc = void (*) (DataBlock &);
 
@@ -71,6 +76,9 @@ class Output {
   bool haveUserDefVariablesFunc = false;
   UserDefVariablesFunc userDefVariablesFunc;
   UserDefVariablesContainer userDefVariables;
+
+  bool sliceEnabled = false;
+  std::vector<std::unique_ptr<Slice>> slices;
 
   Kokkos::Timer timer;
   double elapsedTime{0.0};

--- a/src/output/slice.cpp
+++ b/src/output/slice.cpp
@@ -94,14 +94,14 @@ void Slice::CheckForWrite(DataBlock &data) {
       int beg = data.beg[direction];
       int end = data.end[direction];
       int ntot = data.mygrid->np_int[direction];
-
+      const int dir = direction;
       idefix_for("average",0,NVAR,data.beg[KDIR],data.end[KDIR],
                                   data.beg[JDIR],data.end[JDIR],
                                   data.beg[IDIR],data.end[IDIR],
                   KOKKOS_LAMBDA(int n,int k,int j, int i) {
-                    const int it = (direction == IDIR ? 0 : i);
-                    const int jt = (direction == JDIR ? 0 : j);
-                    const int kt = (direction == KDIR ? 0 : k);
+                    const int it = (dir == IDIR ? 0 : i);
+                    const int jt = (dir == JDIR ? 0 : j);
+                    const int kt = (dir == KDIR ? 0 : k);
 
                     Kokkos::atomic_add(&Vcout(n,kt,jt,it) , Vcin(n,k,j,i)/ntot);
                   });

--- a/src/output/slice.cpp
+++ b/src/output/slice.cpp
@@ -1,0 +1,86 @@
+// ***********************************************************************************
+// Idefix MHD astrophysical code
+// Copyright(C) Geoffroy R. J. Lesur <geoffroy.lesur@univ-grenoble-alpes.fr>
+// and other code contributors
+// Licensed under CeCILL 2.1 License, see COPYING for more information
+// ***********************************************************************************
+
+#include <string>
+#include "slice.hpp"
+#include "input.hpp"
+#include "physics.hpp"
+#include "dataBlock.hpp"
+#include "fluid.hpp"
+
+Slice::Slice(DataBlock & data, int nSlice, SliceType type, int direction, real x0, real period) {
+  idfx::pushRegion("Slice::Slice");
+  std::string prefix = "slice"+std::to_string(nSlice);
+  this->slicePeriod = period;
+  if(slicePeriod> 0) {
+    sliceLast = data.t - slicePeriod;
+  }
+  // Create the slice.
+  this->type = type;
+  this->direction = direction;
+  // Initialize the subgrid
+  this->subgrid = std::make_unique<SubGrid>(data.mygrid, type, direction, x0);
+  // Initialize the associated dataBlock
+  this->sliceData = std::make_unique<DataBlock>(subgrid.get());
+  this->containsX0 = (data.xbeg[direction] <= x0)
+                     && (data.xend[direction] >= x0);
+
+  idfx::cout << data.xbeg[direction] <<" "<< data.xend[direction] << std::endl;
+  // Initialize the vtk routines
+  this->vtk = std::make_unique<Vtk>(sliceData.get(),prefix);
+
+  // Allocate array to compute the slice
+  this->Vc = IdefixArray4D<real>("Slice_Vc", NVAR,
+                                 sliceData->np_tot[KDIR],
+                                 sliceData->np_tot[JDIR],
+                                 sliceData->np_tot[IDIR]);
+
+  vtk->RegisterVariable(Vc, "RHO", RHO);
+  //vtk->RegisterVariable(Vc, "VX1", VX1);
+  idfx::popRegion();
+}
+
+void Slice::CheckForWrite(DataBlock &data) {
+  idfx::pushRegion("Slice:CheckForWrite");
+  // Take the slice (warning with MPI: more work is needed)
+  if(data.t >= sliceLast + slicePeriod) {
+    idfx::cout << "Go johnny" << std::endl;
+    auto Vcin=data.hydro->Vc;
+    auto Vcout=this->Vc;
+    if(containsX0) {
+      // index of element in current datablock
+      const int idx = subgrid->index - data.gbeg[direction]
+                                    + data.beg[direction];
+
+      if(direction == IDIR) {
+        idefix_for("slice",0,NVAR,0,data.np_tot[KDIR],0,data.np_tot[JDIR],
+                  KOKKOS_LAMBDA(int n,int k,int j) {
+                    Vcout(n,k,j,0) = Vcin(n,k,j,idx);
+                  });
+      } else if(direction == JDIR) {
+        idefix_for("slice",0,NVAR,0,data.np_tot[KDIR],0,data.np_tot[IDIR],
+                  KOKKOS_LAMBDA(int n,int k,int i) {
+                    Vcout(n,k,0,i) = Vcin(n,k,idx,i);
+                  });
+      } else if(direction == KDIR) {
+        idefix_for("slice",0,NVAR,0,data.np_tot[JDIR],0,data.np_tot[IDIR],
+                  KOKKOS_LAMBDA(int n,int j,int i) {
+                    Vcout(n,0,j,i) = Vcin(n,idx,j,i);
+                  });
+      }
+      vtk->Write();
+    }
+
+    sliceLast += slicePeriod;
+    if((sliceLast+slicePeriod <= data.t) && slicePeriod > 0.0) {
+      while(sliceLast <= data.t - slicePeriod) {
+        sliceLast += slicePeriod;
+      }
+    }
+  }
+  idfx::popRegion();
+}

--- a/src/output/slice.cpp
+++ b/src/output/slice.cpp
@@ -12,9 +12,9 @@
 #include "dataBlock.hpp"
 #include "fluid.hpp"
 #include "vtk.hpp"
-#include "input.hpp"
 
-Slice::Slice(Input &input, DataBlock & data, int nSlice, SliceType type, int direction, real x0, real period) {
+Slice::Slice(Input &input, DataBlock & data, int nSlice, SliceType type,
+             int direction, real x0, real period) {
   idfx::pushRegion("Slice::Slice");
   std::string prefix = "slice"+std::to_string(nSlice);
   this->slicePeriod = period;

--- a/src/output/slice.cpp
+++ b/src/output/slice.cpp
@@ -12,8 +12,9 @@
 #include "dataBlock.hpp"
 #include "fluid.hpp"
 #include "vtk.hpp"
+#include "input.hpp"
 
-Slice::Slice(DataBlock & data, int nSlice, SliceType type, int direction, real x0, real period) {
+Slice::Slice(Input &input, DataBlock & data, int nSlice, SliceType type, int direction, real x0, real period) {
   idfx::pushRegion("Slice::Slice");
   std::string prefix = "slice"+std::to_string(nSlice);
   this->slicePeriod = period;
@@ -31,7 +32,7 @@ Slice::Slice(DataBlock & data, int nSlice, SliceType type, int direction, real x
                      && (data.xend[direction] >= x0);
 
   // Initialize the vtk routines
-  this->vtk = std::make_unique<Vtk>(sliceData.get(),prefix);
+  this->vtk = std::make_unique<Vtk>(input, sliceData.get(),prefix);
 
   // Allocate array to compute the slice
   this->Vc = IdefixArray4D<real>("Slice_Vc", NVAR,

--- a/src/output/slice.cpp
+++ b/src/output/slice.cpp
@@ -40,7 +40,13 @@ Slice::Slice(DataBlock & data, int nSlice, SliceType type, int direction, real x
                                  sliceData->np_tot[IDIR]);
 
   vtk->RegisterVariable(Vc, "RHO", RHO);
-  //vtk->RegisterVariable(Vc, "VX1", VX1);
+  vtk->RegisterVariable(Vc, "VX1", VX1);
+
+  #if MHD == YES
+  vtk->RegisterVariable(Vc, "BX1", BX1);
+  vtk->RegisterVariable(Vc, "BX2", BX2);
+  vtk->RegisterVariable(Vc, "BX3", BX3);
+  #endif
   idfx::popRegion();
 }
 
@@ -48,7 +54,6 @@ void Slice::CheckForWrite(DataBlock &data) {
   idfx::pushRegion("Slice:CheckForWrite");
   // Take the slice (warning with MPI: more work is needed)
   if(data.t >= sliceLast + slicePeriod) {
-    idfx::cout << "Go johnny" << std::endl;
     auto Vcin=data.hydro->Vc;
     auto Vcout=this->Vc;
     if(containsX0) {

--- a/src/output/slice.hpp
+++ b/src/output/slice.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include "idefix.hpp"
 #include "dataBlock.hpp"
+#include "input.hpp"
 
 class Grid;
 class SubGrid;
@@ -20,7 +21,7 @@ class Vtk;
 
 class Slice {
  public:
-  Slice(DataBlock &, int, SliceType, int, real, real);
+  Slice(Input &, DataBlock &, int, SliceType, int, real, real);
   void CheckForWrite(DataBlock &);
   real slicePeriod = 0.0;
   real sliceLast = 0.0;

--- a/src/output/slice.hpp
+++ b/src/output/slice.hpp
@@ -1,0 +1,37 @@
+// ***********************************************************************************
+// Idefix MHD astrophysical code
+// Copyright(C) Geoffroy R. J. Lesur <geoffroy.lesur@univ-grenoble-alpes.fr>
+// and other code contributors
+// Licensed under CeCILL 2.1 License, see COPYING for more information
+// ***********************************************************************************
+
+
+#ifndef OUTPUT_SLICE_HPP_
+#define OUTPUT_SLICE_HPP_
+
+#include <memory>
+#include "idefix.hpp"
+#include "dataBlock.hpp"
+
+class Grid;
+class SubGrid;
+class Vtk;
+
+
+class Slice {
+ public:
+  Slice(DataBlock &, int, SliceType, int, real, real);
+  void CheckForWrite(DataBlock &);
+  real slicePeriod = 0.0;
+  real sliceLast = 0.0;
+ private:
+  bool containsX0;
+  IdefixArray4D<real> Vc;
+  SliceType type;
+  int direction;
+  std::unique_ptr<SubGrid> subgrid;
+  std::unique_ptr<DataBlock> sliceData;
+  std::unique_ptr<Vtk> vtk;
+};
+
+#endif // OUTPUT_SLICE_HPP_

--- a/src/output/vtk.cpp
+++ b/src/output/vtk.cpp
@@ -39,17 +39,19 @@ void Vtk::WriteHeaderNodes(IdfxFileHandler fvtk) {
   MPI_SAFE_CALL(MPI_File_set_view(fvtk, this->offset, MPI_FLOAT, this->nodeView,
                                   "native", MPI_INFO_NULL));
   MPI_SAFE_CALL(MPI_File_write_all(fvtk, node_coord.data(), size, MPI_FLOAT, MPI_STATUS_IGNORE));
-  this->offset += sizeof(float)*(nx1+IOFFSET)*(nx2+JOFFSET)*(nx3+KOFFSET)*3;
+  this->offset += sizeof(float)*(nx1+ioffset)*(nx2+joffset)*(nx3+koffset)*3;
 #else
   fwrite(node_coord.data(),sizeof(float),size,fvtk);
 #endif
 }
 
 /*init the object */
-Vtk::Vtk(Input &input, DataBlock *datain) {
+Vtk::Vtk(Input &input, DataBlock *datain, std::string filebase) {
   // Initialize the output structure
   // Create a local datablock as an image of gridin
   this->data = datain;
+
+  this->filebase = filebase;
 
   // Pointer to global grid
   GridHost grid(*(datain->mygrid));
@@ -96,23 +98,33 @@ Vtk::Vtk(Input &input, DataBlock *datain) {
   this->nx2loc = data->np_int[JDIR];
   this->nx3loc = data->np_int[KDIR];
 
+  this->ioffset = datain->mygrid->np_tot[IDIR] == 1 ? 0 : 1;
+  this->joffset = datain->mygrid->np_tot[JDIR] == 1 ? 0 : 1;
+  this->koffset = datain->mygrid->np_tot[KDIR] == 1 ? 0 : 1;
+
   // Temporary storage on host for 3D arrays
   this->vect3D = new float[nx1loc*nx2loc*nx3loc];
 
   // Store coordinates for later use
-  this->xnode = new float[nx1+IOFFSET];
-  this->ynode = new float[nx2+JOFFSET];
-  this->znode = new float[nx3+KOFFSET];
+  this->xnode = new float[nx1+ioffset];
+  this->ynode = new float[nx2+joffset];
+  this->znode = new float[nx3+koffset];
 
-  for (int32_t i = 0; i < nx1 + IOFFSET; i++) {
-    xnode[i] = BigEndian(static_cast<float>(grid.xl[IDIR](i + grid.nghost[IDIR])));
+  for (int32_t i = 0; i < nx1 + ioffset; i++) {
+    if(grid.np_tot[IDIR] == 1) // only one dimension in this direction
+      xnode[i] = BigEndian(static_cast<float>(grid.x[IDIR](i)));
+    else
+      xnode[i] = BigEndian(static_cast<float>(grid.xl[IDIR](i + grid.nghost[IDIR])));
   }
-  for (int32_t j = 0; j < nx2 + JOFFSET; j++)    {
-    ynode[j] = BigEndian(static_cast<float>(grid.xl[JDIR](j + grid.nghost[JDIR])));
+  for (int32_t j = 0; j < nx2 + joffset; j++)    {
+    if(grid.np_tot[JDIR] == 1) // only one dimension in this direction
+      ynode[j] = BigEndian(static_cast<float>(grid.x[JDIR](j)));
+    else
+      ynode[j] = BigEndian(static_cast<float>(grid.xl[JDIR](j + grid.nghost[JDIR])));
   }
-  for (int32_t k = 0; k < nx3 + KOFFSET; k++) {
-    if(DIMENSIONS==2)
-      znode[k] = BigEndian(static_cast<float>(0.0));
+  for (int32_t k = 0; k < nx3 + koffset; k++) {
+    if(grid.np_tot[KDIR] == 1)
+      znode[k] = BigEndian(static_cast<float>(grid.x[KDIR](k)));
     else
       znode[k] = BigEndian(static_cast<float>(grid.xl[KDIR](k + grid.nghost[KDIR])));
   }
@@ -138,16 +150,17 @@ Vtk::Vtk(Input &input, DataBlock *datain) {
   // Since we use cell-defined vtk variables,
   // we add one cell in each direction when we're looking at the last
   // sub-domain in each direction
-  nodesize[2] += IOFFSET;
-  nodesize[1] += JOFFSET;
-  nodesize[0] += KOFFSET;
+  nodesize[2] += ioffset;
+  nodesize[1] += joffset;
+  nodesize[0] += koffset;
 
-  if(datain->mygrid->xproc[0] == datain->mygrid->nproc[0]-1) nodesubsize[2] += IOFFSET;
-  if(datain->mygrid->xproc[1] == datain->mygrid->nproc[1]-1) nodesubsize[1] += JOFFSET;
-  if(datain->mygrid->xproc[2] == datain->mygrid->nproc[2]-1) nodesubsize[0] += KOFFSET;
+  if(datain->mygrid->xproc[0] == datain->mygrid->nproc[0]-1) nodesubsize[2] += ioffset;
+  if(datain->mygrid->xproc[1] == datain->mygrid->nproc[1]-1) nodesubsize[1] += joffset;
+  if(datain->mygrid->xproc[2] == datain->mygrid->nproc[2]-1) nodesubsize[0] += koffset;
 
   // Build an MPI view if needed
   #ifdef WITH_MPI
+    // Keep communicator for later use
     MPI_SAFE_CALL(MPI_Type_create_subarray(4, nodesize, nodesubsize, nodestart,
                                           MPI_ORDER_C, MPI_FLOAT, &this->nodeView));
     MPI_SAFE_CALL(MPI_Type_commit(&this->nodeView));
@@ -167,9 +180,9 @@ Vtk::Vtk(Input &input, DataBlock *datain) {
     for (int32_t j = 0; j < nodesubsize[1]; j++) {
       for (int32_t i = 0; i < nodesubsize[2]; i++) {
         // BigEndian allows us to get back to little endian when needed
-        D_EXPAND( x1 = grid.xl[IDIR](i + data->gbeg[IDIR]);  ,
-                  x2 = grid.xl[JDIR](j + data->gbeg[JDIR]);  ,
-                  x3 = grid.xl[KDIR](k + data->gbeg[KDIR]);  )
+          x1 = grid.xl[IDIR](i + data->gbeg[IDIR]);
+          x2 = grid.xl[JDIR](j + data->gbeg[JDIR]);
+          x3 = grid.xl[KDIR](k + data->gbeg[KDIR]);
 
   #if (GEOMETRY == CARTESIAN) || (GEOMETRY == CYLINDRICAL)
         node_coord(k,j,i,0) = BigEndian(x1);
@@ -201,7 +214,7 @@ Vtk::Vtk(Input &input, DataBlock *datain) {
     }
   }
 
-#endif
+#endif // VTK_FORMAT == VTK_STRUCTURED_GRID
 
   // Create MPI view when using MPI I/O
 #ifdef WITH_MPI
@@ -219,10 +232,15 @@ Vtk::Vtk(Input &input, DataBlock *datain) {
   MPI_SAFE_CALL(MPI_Type_create_subarray(3, size, subsize, start, MPI_ORDER_C,
                                          MPI_FLOAT, &this->view));
   MPI_SAFE_CALL(MPI_Type_commit(&this->view));
+  this->comm = datain->mygrid->CartComm;
+  this->isRoot =   (data->mygrid->xproc[0] == 0)
+                && (data->mygrid->xproc[1] == 0)
+                && (data->mygrid->xproc[2] == 0);
 #endif
 
   // Register variables that are required in restart dumps
-  data->dump->RegisterVariable(&vtkFileNumber, "vtkFileNumber");
+  if(data->dump.get() != nullptr)
+    data->dump->RegisterVariable(&vtkFileNumber, "vtkFileNumber");
 }
 
 
@@ -232,21 +250,22 @@ int Vtk::Write() {
   IdfxFileHandler fileHdl;
   std::filesystem::path filename;
 
-  idfx::cout << "Vtk: Write file n " << vtkFileNumber << "..." << std::flush;
+  idfx::cout << "Vtk: Write file " << filename << "..." << std::flush;
 
   timer.reset();
 
   std::stringstream ssfileName, ssvtkFileNum;
   ssvtkFileNum << std::setfill('0') << std::setw(4) << vtkFileNumber;
-  ssfileName << "data." << ssvtkFileNum.str() << ".vtk";
+  ssfileName << filebase << "." << ssvtkFileNum.str() << ".vtk";
   filename = outputDirectory/ssfileName.str();
 
   // Check if file exists, if yes, delete it
-  if(idfx::prank==0) {
+  if(this->isRoot) {
     if(std::filesystem::exists(filename)) {
       std::filesystem::remove(filename);
     }
   }
+
 
   // Open file and write header
 #ifdef WITH_MPI
@@ -271,6 +290,7 @@ int Vtk::Write() {
         for(int i = data->beg[IDIR]; i < data->end[IDIR] ; i++ ) {
           vect3D[i-data->beg[IDIR] + (j-data->beg[JDIR])*nx1loc + (k-data->beg[KDIR])*nx1loc*nx2loc]
               = BigEndian(static_cast<float>(Vcin(k,j,i)));
+             // = BigEndian(static_cast<float>(idfx::prank+1));
         }
       }
     }
@@ -387,7 +407,7 @@ void Vtk::WriteHeader(IdfxFileHandler fvtk, real time) {
 
 
 
-  ssheader << "DIMENSIONS " << nx1 + IOFFSET << " " << nx2 + JOFFSET << " " << nx3 + KOFFSET
+  ssheader << "DIMENSIONS " << nx1 + ioffset << " " << nx2 + joffset << " " << nx3 + koffset
            << std::endl;
 
   header = ssheader.str();
@@ -398,30 +418,30 @@ void Vtk::WriteHeader(IdfxFileHandler fvtk, real time) {
   /* -- Write rectilinear grid information -- */
   std::stringstream coordx, coordy, coordz;
 
-  coordx << "X_COORDINATES " << nx1 + IOFFSET << " float" << std::endl;
+  coordx << "X_COORDINATES " << nx1 + ioffset << " float" << std::endl;
   header = coordx.str();
   WriteHeaderString(header.c_str(), fvtk);
 
-  WriteHeaderBinary(xnode, nx1 + IOFFSET, fvtk);
+  WriteHeaderBinary(xnode, nx1 + ioffset, fvtk);
 
-  coordy << std::endl << "Y_COORDINATES " << nx2 + JOFFSET << " float" << std::endl;
+  coordy << std::endl << "Y_COORDINATES " << nx2 + joffset << " float" << std::endl;
   header = coordy.str();
   WriteHeaderString(header.c_str(), fvtk);
 
-  WriteHeaderBinary(ynode, nx2 + JOFFSET, fvtk);
+  WriteHeaderBinary(ynode, nx2 + joffset, fvtk);
 
-  coordz << std::endl << "Z_COORDINATES " << nx3 + KOFFSET << " float" << std::endl;
+  coordz << std::endl << "Z_COORDINATES " << nx3 + koffset << " float" << std::endl;
   header = coordz.str();
   WriteHeaderString(header.c_str(), fvtk);
 
-  WriteHeaderBinary(znode, nx3 + KOFFSET, fvtk);
+  WriteHeaderBinary(znode, nx3 + koffset, fvtk);
 
 #elif VTK_FORMAT == VTK_STRUCTURED_GRID
 
   /* -- define node_coord -- */
   std::stringstream ssheader2;
 
-  ssheader2 << "POINTS " << (nx1 + IOFFSET) * (nx2 + JOFFSET) * (nx3 + KOFFSET) << " float"
+  ssheader2 << "POINTS " << (nx1 + ioffset) * (nx2 + joffset) * (nx3 + koffset) << " float"
             << std::endl;
   header = ssheader2.str();
   WriteHeaderString(header.c_str(), fvtk);
@@ -461,10 +481,15 @@ void Vtk::WriteScalar(IdfxFileHandler fvtk, float* Vin,  const std::string &var_
 
   WriteHeaderString(header.c_str(), fvtk);
 
+  MPI_Barrier(this->comm);
 #ifdef WITH_MPI
   MPI_SAFE_CALL(MPI_File_set_view(fvtk, this->offset, MPI_FLOAT, this->view,
                                   "native", MPI_INFO_NULL));
-  MPI_SAFE_CALL(MPI_File_write_all(fvtk, Vin, nx1loc*nx2loc*nx3loc, MPI_FLOAT, MPI_STATUS_IGNORE));
+
+  int nwrite = nx1loc*nx2loc*nx3loc;
+  //if(idfx::prank != 0) nwrite = 0;
+  MPI_SAFE_CALL(MPI_File_write_all(fvtk, Vin, nwrite, MPI_FLOAT, MPI_STATUS_IGNORE));
+
   this->offset = this->offset + sizeof(float)*nx1*nx2*nx3;
 #else
   fwrite(Vin,sizeof(float),nx1loc*nx2loc*nx3loc,fvtk);

--- a/src/output/vtk.cpp
+++ b/src/output/vtk.cpp
@@ -250,14 +250,14 @@ int Vtk::Write() {
   IdfxFileHandler fileHdl;
   std::filesystem::path filename;
 
-  idfx::cout << "Vtk: Write file " << filename << "..." << std::flush;
-
   timer.reset();
 
   std::stringstream ssfileName, ssvtkFileNum;
   ssvtkFileNum << std::setfill('0') << std::setw(4) << vtkFileNumber;
   ssfileName << filebase << "." << ssvtkFileNum.str() << ".vtk";
   filename = outputDirectory/ssfileName.str();
+
+  idfx::cout << "Vtk: Write file " << ssfileName.str() << "..." << std::flush;
 
   // Check if file exists, if yes, delete it
   if(this->isRoot) {
@@ -269,9 +269,9 @@ int Vtk::Write() {
 
   // Open file and write header
 #ifdef WITH_MPI
-  MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(this->comm);
   // Open file for creating, return error if file already exists.
-  MPI_SAFE_CALL(MPI_File_open(MPI_COMM_WORLD, filename.c_str(),
+  MPI_SAFE_CALL(MPI_File_open(this->comm, filename.c_str(),
                               MPI_MODE_CREATE | MPI_MODE_RDWR
                               | MPI_MODE_EXCL | MPI_MODE_UNIQUE_OPEN,
                               MPI_INFO_NULL, &fileHdl));

--- a/src/output/vtk.cpp
+++ b/src/output/vtk.cpp
@@ -290,7 +290,6 @@ int Vtk::Write() {
         for(int i = data->beg[IDIR]; i < data->end[IDIR] ; i++ ) {
           vect3D[i-data->beg[IDIR] + (j-data->beg[JDIR])*nx1loc + (k-data->beg[KDIR])*nx1loc*nx2loc]
               = BigEndian(static_cast<float>(Vcin(k,j,i)));
-             // = BigEndian(static_cast<float>(idfx::prank+1));
         }
       }
     }
@@ -481,7 +480,6 @@ void Vtk::WriteScalar(IdfxFileHandler fvtk, float* Vin,  const std::string &var_
 
   WriteHeaderString(header.c_str(), fvtk);
 
-  MPI_Barrier(this->comm);
 #ifdef WITH_MPI
   MPI_SAFE_CALL(MPI_File_set_view(fvtk, this->offset, MPI_FLOAT, this->view,
                                   "native", MPI_INFO_NULL));

--- a/src/output/vtk.hpp
+++ b/src/output/vtk.hpp
@@ -115,7 +115,7 @@ class Vtk : public BaseVtk {
   friend class Dump;
 
  public:
-  explicit Vtk(DataBlock *, std::string filebase = "data");   // init VTK object
+  explicit Vtk(Input &, DataBlock *, std::string filebase = "data");   // init VTK object
   int Write();     // Create a VTK from the current DataBlock
 
   template<typename T>

--- a/src/utils/iterativesolver/bicgstab.hpp
+++ b/src/utils/iterativesolver/bicgstab.hpp
@@ -17,7 +17,7 @@ template <class T>
 class Bicgstab : public IterativeSolver<T> {
  public:
   Bicgstab(T &op, real error, int maxIter,
-           std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
+           std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
 
@@ -40,7 +40,7 @@ class Bicgstab : public IterativeSolver<T> {
 
 template <class T>
 Bicgstab<T>::Bicgstab(T &op, real error, int maxiter,
-            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
+            std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end) :
             IterativeSolver<T>(op, error, maxiter, ntot, beg, end) {
   // BICGSTAB scalars initialisation
   this->rho = 1.0;

--- a/src/utils/iterativesolver/cg.hpp
+++ b/src/utils/iterativesolver/cg.hpp
@@ -17,7 +17,7 @@ template <class T>
 class Cg : public IterativeSolver<T> {
  public:
   Cg(T &op, real error, int maxIter,
-           std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
+           std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
 
@@ -32,7 +32,7 @@ class Cg : public IterativeSolver<T> {
 
 template <class T>
 Cg<T>::Cg(T &op, real error, int maxiter,
-            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
+            std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end) :
             IterativeSolver<T>(op, error, maxiter, ntot, beg, end) {
   // CG scalars initialisation
 

--- a/src/utils/iterativesolver/iterativesolver.hpp
+++ b/src/utils/iterativesolver/iterativesolver.hpp
@@ -16,7 +16,7 @@ template <class T>
 class IterativeSolver {
  public:
   IterativeSolver(T &op, real error, int maxIter,
-                  std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
+                  std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end);
 
   real GetError();  // return the current error of the solver
 
@@ -49,7 +49,7 @@ class IterativeSolver {
 
 template <class T>
 IterativeSolver<T>::IterativeSolver(T &op, real error, int maxiter,
-            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end)
+            std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end)
               : linearOperator(op) {
   this->targetError = error;
   this->maxiter = maxiter;

--- a/src/utils/iterativesolver/iterativesolver.hpp
+++ b/src/utils/iterativesolver/iterativesolver.hpp
@@ -38,9 +38,9 @@ class IterativeSolver {
   bool convStatus;    // Convergence status
   bool restart{false};
 
-  std::vector<int> beg;
-  std::vector<int> end;
-  std::vector<int> ntot;
+  std::array<int,3> beg;
+  std::array<int,3> end;
+  std::array<int,3> ntot;
 
   IdefixArray3D<real> solution;
   IdefixArray3D<real> rhs;

--- a/src/utils/iterativesolver/jacobi.hpp
+++ b/src/utils/iterativesolver/jacobi.hpp
@@ -17,7 +17,7 @@ template <class T>
 class Jacobi : public IterativeSolver<T> {
  public:
   Jacobi(T &op, real error, int maxIter, real step,
-           std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
+           std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
   void ShowConfig();
@@ -29,7 +29,7 @@ class Jacobi : public IterativeSolver<T> {
 
 template <class T>
 Jacobi<T>::Jacobi(T &op, real error, int maxIter, real step,
-           std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
+           std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end) :
             IterativeSolver<T>(op, error, maxIter, ntot, beg, end), dt(step) {
               // do nothing
             }

--- a/src/utils/iterativesolver/minres.hpp
+++ b/src/utils/iterativesolver/minres.hpp
@@ -17,7 +17,7 @@ template <class T>
 class Minres : public IterativeSolver<T> {
  public:
   Minres(T &op, real error, int maxIter,
-           std::vector<int> ntot, std::vector<int> beg, std::vector<int> end);
+           std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end);
 
   int Solve(IdefixArray3D<real> &guess, IdefixArray3D<real> &rhs);
 
@@ -45,7 +45,7 @@ class Minres : public IterativeSolver<T> {
 
 template <class T>
 Minres<T>::Minres(T &op, real error, int maxiter,
-            std::vector<int> ntot, std::vector<int> beg, std::vector<int> end) :
+            std::array<int,3> ntot, std::array<int,3> beg, std::array<int,3> end) :
             IterativeSolver<T>(op, error, maxiter, ntot, beg, end) {
   // MINRES scalars initialisation
   this->alpha = 1.0;

--- a/test/MHD/OrszagTang3D/definitions.hpp
+++ b/test/MHD/OrszagTang3D/definitions.hpp
@@ -1,4 +1,5 @@
 #define     COMPONENTS      3
 #define     DIMENSIONS      3
+//#define DEBUG
 
 #define     GEOMETRY        CARTESIAN


### PR DESCRIPTION
Allow the code to produce 2D slices of the full computational domain in a vtk file.

This MR also transform `std::vector` containers into `std::array` with a fixed size, which simplify the detection of out-of-bound accesses in these arrays.

NB: this PR suffers from a bug in OpenMPI that results into corrupted VTK file in some cases. This still needs to be investigated.