### PR TITLE
MNT: cleanup unused forward declarations

### DIFF
--- a/src/output/output.hpp
+++ b/src/output/output.hpp
@@ -21,9 +21,6 @@
 #include "dump.hpp"
 #include "slice.hpp"
 
-class Vtk;
-class Dump;
-
 using AnalysisFunc = void (*) (DataBlock &);
 
 using UserDefVariablesContainer = std::map<std::string,IdefixHostArray3D<real>>;


### PR DESCRIPTION
Found these at they generated a merge conflict. They seem unneeded since `vtk.hpp` and `dump.hpp` are both unconditionally included already