### PR TITLE
File system compatibility

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -39,6 +39,13 @@ The compilation stops while compiling Kokkos with ``/usr/include/stdlib.h(58): e
 When using the Intel compiler on a Mac Intel, I get a linking error involving the ``SharedAllocationRecordIvvE18t_tracking_enabledE`` symbol.
   This is a known bug of the Intel Mac compiler with Kokkos. Apparently Intel has decided not to fix it. Check the issue on the `Kokkos git page <https://github.com/kokkos/kokkos/issues/1959>`_.
 
+I get an error during *Idefix* link that says there are undefined symbols to std::filesystem
+  This is a known bug/limitation of the stdlibc++ provided with gcc8 that does not include C++17 filesystem extensions.
+  While *Idefix* auto-detects gcc8 when it is used as the main compiler, it still misses the cases when another compiler
+  (like Clang or Intel) is used with gcc8 as a backend.
+  You should try to clear up CMakeCache.txt and explicitely add the required link library when calling cmake as in
+  ``LDFLAGS=-lstdc++fs cmake $IDEFIX_DIR ...```
+
 Execution
 ---------
 

--- a/src/output/dump.hpp
+++ b/src/output/dump.hpp
@@ -9,8 +9,15 @@
 #define OUTPUT_DUMP_HPP_
 #include <string>
 #include <map>
-#include <filesystem>
-
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  error "Missing the <filesystem> header."
+#endif
 #include "idefix.hpp"
 #include "input.hpp"
 #include "dataBlock.hpp"
@@ -232,9 +239,9 @@ class Dump {
   void ReadSerial(IdfxFileHandler, int, int*, DataType, void*);
   void ReadDistributed(IdfxFileHandler, int, int*, int*, IdfxDataDescriptor&, void*);
   void Skip(IdfxFileHandler, int, int *, DataType);
-  int GetLastDumpInDirectory(std::filesystem::path &);
+  int GetLastDumpInDirectory(fs::path &);
 
-  std::filesystem::path outputDirectory;
+  fs::path outputDirectory;
 };
 
 

--- a/src/output/vtk.cpp
+++ b/src/output/vtk.cpp
@@ -8,7 +8,15 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
-#include <filesystem>
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  error "Missing the <filesystem> header."
+#endif
 #include "vtk.hpp"
 #include "version.hpp"
 #include "idefix.hpp"
@@ -64,9 +72,9 @@ Vtk::Vtk(Input &input, DataBlock *datain, std::string filebase) {
   }
 
   if(idfx::prank==0) {
-    if(!std::filesystem::is_directory(outputDirectory)) {
+    if(!fs::is_directory(outputDirectory)) {
       try {
-        if(!std::filesystem::create_directory(outputDirectory)) {
+        if(!fs::create_directory(outputDirectory)) {
           std::stringstream msg;
           msg << "Cannot create directory " << outputDirectory << std::endl;
           IDEFIX_ERROR(msg);
@@ -247,7 +255,7 @@ int Vtk::Write() {
   idfx::pushRegion("Vtk::Write");
 
   IdfxFileHandler fileHdl;
-  std::filesystem::path filename;
+  fs::path filename;
 
   timer.reset();
 
@@ -260,8 +268,8 @@ int Vtk::Write() {
 
   // Check if file exists, if yes, delete it
   if(this->isRoot) {
-    if(std::filesystem::exists(filename)) {
-      std::filesystem::remove(filename);
+    if(fs::exists(filename)) {
+      fs::remove(filename);
     }
   }
 

--- a/src/output/vtk.hpp
+++ b/src/output/vtk.hpp
@@ -9,7 +9,15 @@
 #define OUTPUT_VTK_HPP_
 #include <string>
 #include <map>
-#include <filesystem>
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  error "Missing the <filesystem> header."
+#endif
 #include "idefix.hpp"
 #include "input.hpp"
 #include "dataBlock.hpp"
@@ -158,7 +166,7 @@ class Vtk : public BaseVtk {
   void WriteHeaderNodes(IdfxFileHandler);
 
   // output directory
-  std::filesystem::path outputDirectory;
+  fs::path outputDirectory;
 };
 
 template<typename T>


### PR DESCRIPTION
Fix `std::filesystem` compatibility with some old compiler/stdlibc++ (as spotted in the Lumi cluster)