### PR TITLE
RFC: simplify RUNTIME_CHECK_KERNEL's signature using Kokkos::printf

### DIFF
--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -173,25 +173,17 @@
     } \
   }
 
-  #if defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_CUDA)
-    // string formatting functions can't be accessed from GPU kernels,
-    // so we fallback to a simple error message
-    #define RUNTIME_CHECK_KERNEL(condition, fallback_msg, ...) { \
-      if(!(condition)) Kokkos::abort(fallback_msg); \
-    }
-  #else
-    #define RUNTIME_CHECK_KERNEL(condition, fallback_msg, ...) { \
-      if(!(condition)) { \
-        char msg[255]; \
-        snprintf(msg, sizeof(msg), __VA_ARGS__); \
-        Kokkos::abort(msg); \
-      } \
-    }
-  #endif // if defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_CUDA)
+  #define RUNTIME_CHECK_KERNEL(condition, ...) { \
+    if(!(condition)) { \
+      char msg[255]; \
+      Kokkos::printf(msg, __VA_ARGS__); \
+      Kokkos::abort(msg); \
+    } \
+  }
 
 #else
-  #define RUNTIME_CHECK_HOST(condition, msg, ...) {}
-  #define RUNTIME_CHECK_KERNEL(condition, fallback_msg, ...) {}
+  #define RUNTIME_CHECK_HOST(condition, ...) {}
+  #define RUNTIME_CHECK_KERNEL(condition, ...) {}
 #endif // ifdef RUNTIME_CHECKS
 
 


### PR DESCRIPTION
based on #216

Although technically a breaking change, I don't expect `RUNTIME_CHECK_KERNEL` to be already in use in the wild, and in any case it's not meant to be used in prod, so I assume this can go straight to master ?