### PR TITLE
fix an overflow in dump restart routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cleanup planet test (#212)
 - allow the use of IdefixHostArrays as inputs for the LookupTable class (#214)
 - use Felker & Stone (2018) PPM scheme when using HIGH_ORDER_FARGO in place of Colella & Woodward (1984) (#218).
+- fix a bug that could result in segfaults when reading a restart dump, in particular in 1D problems with MPI (#219).
 
 ## [2.0.2] 2023-11-6
 ### Changed

--- a/src/output/dump.cpp
+++ b/src/output/dump.cpp
@@ -5,6 +5,7 @@
 // Licensed under CeCILL 2.1 License, see COPYING for more information
 // ***********************************************************************************
 
+#include <algorithm>
 #include <unordered_set>
 #if __has_include(<filesystem>)
   #include <filesystem>

--- a/src/output/dump.cpp
+++ b/src/output/dump.cpp
@@ -88,9 +88,16 @@ void Dump::Init(DataBlock *datain) {
   }
 
   // Allocate scratch Array
-  this->scrch = new real[ (data->np_int[IDIR]+IOFFSET)*
-                          (data->np_int[JDIR]+JOFFSET)*
-                          (data->np_int[KDIR]+KOFFSET)];
+  // It must be able to handle either a full domain 1D Array and
+  // a sub-3D somain
+  int64_t nmax = (data->np_int[IDIR]+IOFFSET)*
+                  (data->np_int[JDIR]+JOFFSET)*
+                  (data->np_int[KDIR]+KOFFSET);
+  nmax = std::max(nmax,static_cast<int64_t>(data->mygrid->np_tot[IDIR]));
+  nmax = std::max(nmax,static_cast<int64_t>(data->mygrid->np_tot[JDIR]));
+  nmax = std::max(nmax,static_cast<int64_t>(data->mygrid->np_tot[KDIR]));
+
+  this->scrch = new real[nmax];
 
   #ifdef WITH_MPI
     Grid *grid = data->mygrid;


### PR DESCRIPTION
This overflow could results in segfaults in 1D problems with MPI that loads restart dumps.