### PR TITLE
fix a bug identified in gcc 9.3.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - allow the use of IdefixHostArrays as inputs for the LookupTable class (#214)
 - use Felker & Stone (2018) PPM scheme when using HIGH_ORDER_FARGO in place of Colella & Woodward (1984) (#218).
 - fix a bug that could result in segfaults when reading a restart dump, in particular in 1D problems with MPI (#219).
+- fix a bug preventing compilation on gcc 9.3.0 (#220)
 
 ## [2.0.2] 2023-11-6
 ### Changed

--- a/src/fluid/braginskii/bragThermalDiffusion.hpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.hpp
@@ -73,12 +73,12 @@ class BragThermalDiffusion {
 
 template <typename Phys>
 BragThermalDiffusion::BragThermalDiffusion(Input &input, Grid &grid, Fluid<Phys> *hydroin):
-                            Vc{hydroin->Vc},
-                            Vs{hydroin->Vs},
-                            dMax{hydroin->dMax},
-                            eos{hydroin->eos.get()},
-                            data{hydroin->data},
-                            status{hydroin->bragThermalDiffusionStatus} {
+                            Vc(hydroin->Vc),
+                            Vs(hydroin->Vs),
+                            dMax(hydroin->dMax),
+                            eos(hydroin->eos.get()),
+                            data(hydroin->data),
+                            status(hydroin->bragThermalDiffusionStatus) {
   idfx::pushRegion("BragThermalDiffusion::BragThermalDiffusion");
 
   if(input.CheckEntry("Hydro","bragTDiffusion")>=0) {

--- a/src/fluid/braginskii/bragViscosity.hpp
+++ b/src/fluid/braginskii/bragViscosity.hpp
@@ -67,10 +67,10 @@ class BragViscosity {
 
 template<typename Phys>
 BragViscosity::BragViscosity(Input &input, Grid &grid, Fluid<Phys> *hydroin):
-                      Vc{hydroin->Vc},
-                      Vs{hydroin->Vs},
-                      dMax{hydroin->dMax},
-                      status{hydroin->bragViscosityStatus} {
+                      Vc(hydroin->Vc),
+                      Vs(hydroin->Vs),
+                      dMax(hydroin->dMax),
+                      status(hydroin->bragViscosityStatus) {
   idfx::pushRegion("BragViscosity::BragViscosity");
   // Save the parent hydro object
   this->data = hydroin->data;

--- a/src/fluid/thermalDiffusion.hpp
+++ b/src/fluid/thermalDiffusion.hpp
@@ -64,11 +64,11 @@ class ThermalDiffusion {
 
 template <typename Phys>
 ThermalDiffusion::ThermalDiffusion(Input &input, Grid &grid, Fluid<Phys> *hydroin):
-                            Vc{hydroin->Vc},
-                            dMax{hydroin->dMax},
-                            eos{hydroin->eos.get()},
-                            data{hydroin->data},
-                            status{hydroin->thermalDiffusionStatus} {
+                            Vc(hydroin->Vc),
+                            dMax(hydroin->dMax),
+                            eos(hydroin->eos.get()),
+                            data(hydroin->data),
+                            status(hydroin->thermalDiffusionStatus) {
   idfx::pushRegion("ThermalDiffusion::ThermalDiffusion");
 
   if(status.status == Constant) {

--- a/src/fluid/viscosity.hpp
+++ b/src/fluid/viscosity.hpp
@@ -66,9 +66,9 @@ class Viscosity {
 
 template<typename Phys>
 Viscosity::Viscosity(Input &input, Grid &grid, Fluid<Phys> *hydroin):
-                      Vc{hydroin->Vc},
-                      dMax{hydroin->dMax},
-                      status{hydroin->viscosityStatus} {
+                      Vc(hydroin->Vc),
+                      dMax(hydroin->dMax),
+                      status(hydroin->viscosityStatus) {
   idfx::pushRegion("Viscosity::Viscosity");
   // Save the parent hydro object
   this->data = hydroin->data;


### PR DESCRIPTION
 fix the bug` initial value of reference to non-const must be an lvalue`
found in gcc 9.3.0 (probably a compiler bug as this does not show up anywhere else)