### PR TITLE
incorrect max diffusion with resistivity

### DIFF
--- a/src/fluid/addNonIdealMHDFlux.hpp
+++ b/src/fluid/addNonIdealMHDFlux.hpp
@@ -258,7 +258,7 @@ void Fluid<Phys>::AddNonIdealMHDFlux(const real t) {
             #if HAVE_ENERGY
               Flux(ENG,k,j,i) += - Bx1 * eta * Jx2 + Bx2 * eta * Jx1;
             #endif
-            dMax(k,j,i) += eta;
+            locdmax += eta;
           }
 
           if(haveAmbipolar) {


### PR DESCRIPTION
Fix a bug that could result in too restrictive timesteps when resistivity is enabled

fix #242