### PR TITLE
Per proc normalisation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -55,7 +55,7 @@ Terms and condition of Use
 ===========================
 *Idefix* is distributed freely under the `CeCILL license <https://en.wikipedia.org/wiki/CeCILL>`_, a free software license adapted to both international and French legal matters, in the spirit of and retaining
 compatibility with the GNU General Public License (GPL). We expect *Idefix* to be referenced and acknowledeged by authors in their publications. At the minimum, the authors
-should cite the *Idefix* `method paper <https://ui.adsabs.harvard.edu/abs/2023arXiv230413746L/abstract>`_.
+should cite the *Idefix* `method paper <https://ui.adsabs.harvard.edu/abs/2023A%26A...677A...9L/abstract>`_.
 
 *Idefix* data structure and algorithm are derived from Andrea Mignone's `PLUTO code <http://plutocode.ph.unito.it/>`_, released under the GPL license.
 *Idefix* also relies on the `Kokkos <https://github.com/kokkos/kokkos>`_ performance portability programming ecosystem released under the terms
@@ -108,6 +108,7 @@ under the European Union Horizon 2020 research and innovation programme (Grant a
    reference
    modules
    programmingguide
+   performances
    kokkos
    contributing
    faq

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -74,6 +74,9 @@ Soufiane Baghdadi
 Gaylor Wafflard-Fernandez
   planet-disc interaction
 
+Jonah Mauxion
+  self-gravity module
+
 Clément Robert
   gitlab integration, linter
 
@@ -96,8 +99,12 @@ This documentation has automatically been generated on |today| from the followin
 Acknowledgements
 ===================
 
-The developement of *Idefix* is supported by the European Research Council (ERC)
-under the European Union Horizon 2020 research and innovation programme (Grant agreement No. 815559 (MHDiscs))
+The developement of *Idefix* was supported by the European Research Council (ERC)
+under the European Union Horizon 2020 research and innovation programme (Grant agreement No. 815559 (MHDiscs)).
+Idefix developement team is partly funded by the `PEPR Origins <https://pepr-origins.fr>`_ through the project "MHD@Exascale".
+The Idefix collaboration benefited from funding from the “Programme National de Physique Stellaire” (PNPS),
+“Programme National Soleil-Terre” (PNST), “Programme National de Hautes Energies” (PNHE) and
+“Programme National de Planétologie” (PNP) of CNRS/INSU co-funded by CEA and CNES.
 
 
 .. toctree::

--- a/doc/source/performances.rst
+++ b/doc/source/performances.rst
@@ -1,0 +1,48 @@
+======================
+Performances
+======================
+
+We report below the performances obtained on various architectures using Idefix. The reference test
+is the 3D MHD Orszag-Tang test problem with 2nd order reconstruction and uct_contact EMFS bundled in
+Idefix test suite, computed with a 128\ :sup:`3` resolution per MPI sub-domain on GPUs or 32\ :sup:`3`
+per MPI sub-domain on CPUs. All of the performances measures have been obtained enabling MPI on
+*one full node*, but we report here the performance *per GPU*
+(i.e. with 2 GCDs on AMD Mi250) or *per core* (on CPU), i.e. dividing the node performance by the number of GPU/core
+to simplify the comparison with other clusters.
+
+The complete scalability tests are available in Idefix `method paper <https://ui.adsabs.harvard.edu/abs/2023A%26A...677A...9L/abstract>`_.
+The performances mentionned below are updated for each major revision of Idefix, so they might slightly differ from the method paper.
+
+.. note::
+
+    You might expect
+    slower performances with lower resolution when using GPUs. The overall performances also depends on
+    the physical modules activated, the reconstruction scheme, and the efficiency of the parallel network
+    on which you are running. The performances reported below are therefore purely indicative. We encourage
+    you to use the embedded profiler (see :ref:`commandLine` ) when performances are smaller than expected.
+
+
+CPU performances
+================
+
++---------------------+--------------------+----------------------------------------------------+
+| Cluster name        | Processor          | Performances (in 10\ :sup:`6` cell/s/core)         |
++=====================+====================+====================================================+
+| TGCC/Irene Rome     | AMD EPYC Rome      | 0.29                                               |
++---------------------+--------------------+----------------------------------------------------+
+| IDRIS/Jean Zay      | Intel Cascade Lake | 0.62                                               |
++---------------------+--------------------+----------------------------------------------------+
+
+
+GPU performances
+================
+
++----------------------+--------------------+----------------------------------------------------+
+| Cluster name         | GPU                | Performances (in 10\ :sup:`6` cell/s/GPU)          |
++======================+====================+====================================================+
+| IDRIS/Jean Zay       | NVIDIA V100        | 110                                                |
++----------------------+--------------------+----------------------------------------------------+
+| IDRIS/Jean Zay       | NVIDIA A100        | 194                                                |
++----------------------+--------------------+----------------------------------------------------+
+| CINES/Adastra        | AMD Mi250          | 250                                                |
++----------------------+--------------------+----------------------------------------------------+

--- a/doc/source/reference/makefile.rst
+++ b/doc/source/reference/makefile.rst
@@ -108,15 +108,17 @@ We recommend the following modules and environement variables on AdAstra:
 
 .. code-block:: bash
 
-    module load PrgEnv-cray-amd
-    module load cray-mpich
-    module load craype-network-ofi
-    module load cce
-    module load cpe
-    module load rocm/5.2.0
-    export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64 -lstdc++fs"
+    module load cpe/23.12
+    module load craype-accel-amd-gfx90a craype-x86-trento
+    module load PrgEnv-cray
+    module load amd-mixed/5.7.1
+    module load rocm/5.7.1 # nécessaire a cause d'un bug de path pas encore fix..
+    export HIPCC_COMPILE_FLAGS_APPEND="-isystem ${CRAY_MPICH_PREFIX}/include"
+    export HIPCC_LINK_FLAGS_APPEND="-L${CRAY_MPICH_PREFIX}/lib -lmpi ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a} -lstdc++fs"
+    export CXX=hipcc
+    export CC=hipcc
 
-The last line being there to guarantee the link to the HIP library and the access to specific
+The `-lstdc++fs` option being there to guarantee the link to the HIP library and the access to specific
 C++17 <filesystem> functions.
 
 Finally, *Idefix* can be configured to run on Mi250 by enabling HIP and the desired architecture with the following options to ccmake:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,7 +200,7 @@ int main( int argc, char* argv[] ) {
     n_seconds = divres.rem;
 
     double perfs = timer.seconds() / grid.np_int[IDIR] / grid.np_int[JDIR]
-                            / grid.np_int[KDIR] / Tint.GetNCycles();
+                            / grid.np_int[KDIR] / Tint.GetNCycles() / idfx::psize;
 
     idfx::cout << "Main: Reached t=" << data.t << std::endl;
     idfx::cout << "Main: Completed in ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,7 +200,7 @@ int main( int argc, char* argv[] ) {
     n_seconds = divres.rem;
 
     double perfs = timer.seconds() / grid.np_int[IDIR] / grid.np_int[JDIR]
-                            / grid.np_int[KDIR] / Tint.GetNCycles() / idfx::psize;
+                            / grid.np_int[KDIR] / Tint.GetNCycles() * idfx::psize;
 
     idfx::cout << "Main: Reached t=" << data.t << std::endl;
     idfx::cout << "Main: Completed in ";

--- a/src/timeIntegrator.cpp
+++ b/src/timeIntegrator.cpp
@@ -88,7 +88,7 @@ TimeIntegrator::TimeIntegrator(Input & input, DataBlock & data) {
 void TimeIntegrator::ShowLog(DataBlock &data) {
   if(isSilent) return;
   double rawperf = (timer.seconds()-lastLog)/data.mygrid->np_int[IDIR]/data.mygrid->np_int[JDIR]
-                      /data.mygrid->np_int[KDIR]/cyclePeriod;
+                      /data.mygrid->np_int[KDIR]/cyclePeriod/idfx::psize;
 #ifdef WITH_MPI
   // measure time spent in expensive MPI calls
   double mpiCycleTime = idfx::mpiCallsTimer - lastMpiLog;

--- a/src/timeIntegrator.cpp
+++ b/src/timeIntegrator.cpp
@@ -88,7 +88,7 @@ TimeIntegrator::TimeIntegrator(Input & input, DataBlock & data) {
 void TimeIntegrator::ShowLog(DataBlock &data) {
   if(isSilent) return;
   double rawperf = (timer.seconds()-lastLog)/data.mygrid->np_int[IDIR]/data.mygrid->np_int[JDIR]
-                      /data.mygrid->np_int[KDIR]/cyclePeriod/idfx::psize;
+                      /data.mygrid->np_int[KDIR]/cyclePeriod * idfx::psize;
 #ifdef WITH_MPI
   // measure time spent in expensive MPI calls
   double mpiCycleTime = idfx::mpiCallsTimer - lastMpiLog;


### PR DESCRIPTION
- Show performance per MPI process instead of global
- Add performance measures from typical architectures in the documentation