### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 <!-- toc -->
 
+- [What is Idefix?](#what-is-idefix)
 - [Download:](#download)
 - [Installation:](#installation)
 - [Compile an example:](#compile-an-example)
@@ -16,6 +17,29 @@
 - [Contributing](#contributing)
 
 <!-- tocstop -->
+
+What is Idefix?
+---------------
+Idefix is a computational fluid dynamics code based on a finite-volume high-order Godunov method, originally designed for astrophysical fluid dynamics applications.  Idefix is designed to be performance-portable, and uses the Kokkos framework to achieve this goal. This means that it can run both on your laptop's cpu and on the largest GPU Exascale clusters. More technically, Idefix can run in serial, use OpenMP and/or MPI (message passing interface) for parallelization, and use GPU acceleration when available (based on Nvidia Cuda, AMD HIP, etc...). All these capabilities are embedded within one single code, so the code relies on relatively abstracted classes and objects available in C++17, which are not necessarily
+familiar to astrophysicists. A large effort has been devoted to simplify this level of abstraction so that the code can be modified by researchers and students familiar with C and who are aware of basic object-oriented concepts.
+
+
+Idefix currently supports the following physics:
+
+* Compressible hydrodynamics in 1D, 2D, 3D
+* Compressible magnetohydrodynamics using constrained transport in 1D, 2D, 3D
+* Multiple geometry (cartesian, polar, spherical)
+* Variable mesh spacing
+* Multiple parallelisation strategies (OpenMP, MPI, GPU offloading, etc...)
+* Full non-ideal MHD (Ohmic, ambipolar, Hall)
+* Viscosity and thermal diffusion
+* Super-timestepping for all parabolic terms
+* Orbital advection (Fargo-like)
+* Self-gravity
+* Multi dust species modelled as pressureless fluids
+* Multiple planets interraction
+
+
 
 Download:
 ---------

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <!-- toc -->
 
 - [What is Idefix?](#what-is-idefix)
+- [Documentation](#documentation)
 - [Download:](#download)
 - [Installation:](#installation)
 - [Compile an example:](#compile-an-example)
@@ -20,7 +21,7 @@
 
 What is Idefix?
 ---------------
-Idefix is a computational fluid dynamics code based on a finite-volume high-order Godunov method, originally designed for astrophysical fluid dynamics applications.  Idefix is designed to be performance-portable, and uses the Kokkos framework to achieve this goal. This means that it can run both on your laptop's cpu and on the largest GPU Exascale clusters. More technically, Idefix can run in serial, use OpenMP and/or MPI (message passing interface) for parallelization, and use GPU acceleration when available (based on Nvidia Cuda, AMD HIP, etc...). All these capabilities are embedded within one single code, so the code relies on relatively abstracted classes and objects available in C++17, which are not necessarily
+Idefix is a computational fluid dynamics code based on a finite-volume high-order Godunov method, originally designed for astrophysical fluid dynamics applications.  Idefix is designed to be performance-portable, and uses the [Kokkos](https://github.com/kokkos/kokkos) framework to achieve this goal. This means that it can run both on your laptop's cpu and on the largest GPU Exascale clusters. More technically, Idefix can run in serial, use OpenMP and/or MPI (message passing interface) for parallelization, and use GPU acceleration when available (based on Nvidia Cuda, AMD HIP, etc...). All these capabilities are embedded within one single code, so the code relies on relatively abstracted classes and objects available in C++17, which are not necessarily
 familiar to astrophysicists. A large effort has been devoted to simplify this level of abstraction so that the code can be modified by researchers and students familiar with C and who are aware of basic object-oriented concepts.
 
 
@@ -39,6 +40,10 @@ Idefix currently supports the following physics:
 * Multi dust species modelled as pressureless fluids
 * Multiple planets interraction
 
+Documentation
+-------------
+
+A full online documentation is available on [readTheDoc](https://idefix.readthedocs.io/latest/).
 
 
 Download:
@@ -80,10 +85,8 @@ Configure the code launching cmake (version >= 3.16) in the example directory:
 cmake $IDEFIX_DIR
 ```
 
-Several options can be enabled from the command line (a complete list is available with `cmake $IDEFIX_DIR -LH`). For instance: `-DIdefix_RECONSTRUCTION=Parabolic` (enable PPM reconstruction), `-DIdefix_MPI=ON` (enable mpi), `-DKokkos_ENABLE_OPENMP=ON` (enable openmp parallelisation), etc... For more complex target architectures, it is recommended to use cmake GUI launching `ccmake $IDEFIX_DIR` in place of `cmake` and then switching on the required options.
+Several options can be enabled from the command line (a complete list is available with `cmake $IDEFIX_DIR -LH`). For instance: `-DIdefix_RECONSTRUCTION=Parabolic` (enable PPM reconstruction), `-DIdefix_MPI=ON` (enable mpi), `-DKokkos_ENABLE_OPENMP=ON` (enable openmp parallelisation), etc... For more complex target architectures, it is recommended to use cmake GUI launching `ccmake $IDEFIX_DIR` in place of `cmake` and then switching on the required options. See the [online documentation](https://idefix.readthedocs.io/latest/) for details.
 
-Optional xdmf(hdf5+xmf) file dumping feature has been added to `Idefix`. This uses either serial or parallel implementation of `hdf5` library which needs to be made available. These xdmf file pairs can be easily visualized in `ParaView` or `VisIt` by loading the `xmf` files. The `hdf5` files can also be loaded easily in `python` (using `h5py`) for post-processing and post-run analysis. One can turn on `xdmf` data dumps by using `-DIdefix_HDF5=ON`. The `[Output]` block of `.ini` file is checked during runtime for a `xdmf` entry whih controls the frequency of xdmf file dumps during code execution.
-<!-- TODO: HDF5 Chunking and Compression filters -->
 
 One can then compile the code:
 

--- a/doc/source/reference/makefile.rst
+++ b/doc/source/reference/makefile.rst
@@ -146,15 +146,16 @@ We recommend the following modules and environement variables on Jean Zay:
 
 .. code-block:: bash
 
-    -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_VOLTA70=ON
+    -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_VOLTA70=ON -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF
 
 While Ampere A100 GPUs are enabled with
 
 .. code-block:: bash
 
-    -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_AMPERE80=ON
+    -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_AMPERE80=ON -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF
 
-MPI (multi-GPU) can be enabled by adding ``-DIdefix_MPI=ON`` as usual.
+MPI (multi-GPU) can be enabled by adding ``-DIdefix_MPI=ON`` as usual. The malloc async option is here to prevent a bug when using PSM2 with async
+cuda malloc possibly leading to openmpi crash or hangs on the Jean Zay machine.
 
 .. _setupSpecificOptions:
 

--- a/doc/source/reference/makefile.rst
+++ b/doc/source/reference/makefile.rst
@@ -176,7 +176,7 @@ explicitely the options as they are required, using the functions ``set_idefix_p
 
 .. _customSourceFiles:
 
-Add/replace custom source files
+Add custom source files
 +++++++++++++++++++++++++++++++
 
 It is possible to add custom source files to be compiled and linked against *Idefix*. This can be useful
@@ -189,21 +189,6 @@ say you want to add source files for an analysis, your ``CMakeLists.txt`` should
 
     add_idefix_source(analysis.cpp)
     add_idefix_source(analysis.hpp)
-
-
-*Idefix* also allows one to replace a source file in `$IDEFIX_DIR` by your own implementation. This is useful when developping new functionnalities without touching
-the main directory of your *Idefix* repository. For instance, say one wants to replace the implementation of viscosity in `$IDEFIX_SRC/src/hydro/viscosity.cpp`,
-with a customised `myviscosity.cpp` in the problem directory, one should add a ``CMakeLists.txt`` in the problem directory reading
-
-.. code-block::
-    :caption: CMakeLists.txt
-
-    replace_idefix_source(hydro/viscosity.cpp myviscosity.cpp)
-
-
-Note that the first parameter of ``replace_idefix_source`` is used as a search pattern in `$IDEFIX_DIR`. Hence it is possible to ommit the parent directory
-of the file being replaced if there is only one file with that name in the *Idefix* source directory, which is not guaranteed (some classes may implement
-methods with the same name). It is therefore recommended to add the parent directory in the first argument of ``replace_idefix_source``.
 
 
 .. tip::

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -226,6 +226,12 @@ void Input::ShowConfig() {
   idfx::cout << "-----------------------------------------------------------------------------"
              << std::endl;
 
+  std::stringstream os;
+  Kokkos::DefaultExecutionSpace().print_configuration(os, true);
+  idfx::cout << "Input: Kokkos configuration" << std::endl << os.str();
+  idfx::cout << "-----------------------------------------------------------------------------"
+             << std::endl;
+
   #ifdef SINGLE_PRECISION
     idfx::cout << "Input: Compiled with SINGLE PRECISION arithmetic." << std::endl;
   #else
@@ -236,15 +242,6 @@ void Input::ShowConfig() {
   idfx::cout << "Input: COMPONENTS=" << COMPONENTS << "." << std::endl;
   #ifdef WITH_MPI
     idfx::cout << "Input: MPI ENABLED." << std::endl;
-  #endif
-  #ifdef KOKKOS_ENABLE_HIP
-    idfx::cout << "Input: Kokkos HIP target ENABLED." << std::endl;
-  #endif
-  #ifdef KOKKOS_ENABLE_CUDA
-    idfx::cout << "Input: Kokkos CUDA target ENABLED." << std::endl;
-  #endif
-  #ifdef KOKKOS_ENABLE_OPENMP
-    idfx::cout << "Input: Kokkos OpenMP ENABLED." << std::endl;
   #endif
 }
 


### PR DESCRIPTION
- add Kokkos information on startup
- remove idefix_replace_source documentation as this is not supported for .hpp files and lead to mistakes for users
- add information on the code in the Readme file
- remove specific hdf5 info in the Readme file
- add the cuda_async flag for Jean Zay options following the transition to Kokkos 4.3, where cuda_async is now default, and lead to problems with the PSM2 library. 