### PR TITLE
set built type as default (allow user override)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
-set(CMAKE_BUILD_TYPE Release)
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
 set (CMAKE_CXX_STANDARD 17)
 
 set(Idefix_VERSION_MAJOR 2)


### PR DESCRIPTION
change release built type to default so it can be overridden by cmake command line arguments.