### PR TITLE
Make shockFlattening public

### DIFF
--- a/src/fluid/RiemannSolver/riemannSolver.hpp
+++ b/src/fluid/RiemannSolver/riemannSolver.hpp
@@ -62,6 +62,8 @@ class RiemannSolver {
   template<int dir>
   ExtrapolateToFaces<Phys, dir>* GetExtrapolator();
 
+  std::unique_ptr<ShockFlattening<Phys>> shockFlattening;
+
  private:
   template <typename P, int dir, PLMLimiter L, int O>
   friend class ExtrapolateToFaces;
@@ -74,8 +76,6 @@ class RiemannSolver {
   DataBlock *data;
 
   Solver mySolver;
-
-  std::unique_ptr<ShockFlattening<Phys>> shockFlattening;
 
   // Because each direction is a different template, we can't use
   std::unique_ptr<ExtrapolateToFaces<Phys,IDIR>> slopeLimIDIR;


### PR DESCRIPTION
`shockFlattening` member of `RiemannSolver` class is set to be public, otherwise `ShockFlattening::EnrollUserShockFlag` can not be accessed from a custom setup.