### PR TITLE
[FIX] xdmf datatype agnostic dump

### DIFF
--- a/src/output/xdmf.cpp
+++ b/src/output/xdmf.cpp
@@ -165,7 +165,7 @@ Xdmf::Xdmf(Input &input, DataBlock *datain) {
                                                                  cellsubsize[3]);
   */
   // Temporary storage on host for 3D arrays
-  this->vect3D = new float[nx1loc*nx2loc*nx3loc];
+  this->vect3D = new DUMP_DATATYPE[nx1loc*nx2loc*nx3loc];
 
   // fill the node_coord array
   DUMP_DATATYPE x1 = 0.0;


### PR DESCRIPTION
On running `cmake` with `cmake $IDEFIX_DIR -DIdefix_HDF5=ON -DCMAKE_CXX_FLAGS="-DXDMF_DOUBLE"`, the following compilation error is generated:
```
idefix/src/output/xdmf.cpp:168:18: error: incompatible pointer types assigning to 'double *' from 'float *'
  this->vect3D = new float[nx1loc*nx2loc*nx3loc];
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
This is because it works well for the default option `float` but when the dumping datatype is changed to `double`, the code complains as the right hand side of this expression is still `float` which must be changed to `double`. Therefore, to make this dump datatype agnostic, one needs to change `float` on the right hand side of this expression to `DUMP_DATATYPE` macro.