### PR TITLE
Custom directory for dumping of log files

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -26,6 +26,7 @@ bool warningsAreErrors{false};
 
 IdefixOutStream cout;
 IdefixErrStream cerr;
+std::string logFileDir;
 Profiler prof;
 LoopPattern defaultLoopPattern;
 
@@ -103,8 +104,8 @@ void IdefixOutStream::init(int rank) {
 // disable the log file
 void IdefixOutStream::enableLogFile() {
   std::stringstream sslogFileName;
-  sslogFileName << "idefix." << idfx::prank << ".log";
-
+    
+  sslogFileName << idfx::logFileDir << "/./"  << "idefix." << idfx::prank << ".log";
   std::string logFileName(sslogFileName.str());
   this->my_fstream.open(logFileName.c_str());
 

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -21,6 +21,7 @@ class Profiler;
 
 extern int prank;                       //< parallel rank
 extern int psize;
+extern std::string logFileDir;       //< logfileDir
 extern IdefixOutStream cout;              //< custom cout for idefix
 extern IdefixErrStream cerr;              //< custom cerr for idefix
 extern Profiler prof;                   //< profiler (for memory & performance usage)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -43,6 +43,7 @@ Input::Input(int argc, char* argv[] ) {
   bool haveBlock = false;
   std::stringstream msg;
   int nParameters = 0;    // # of parameters in current block
+  this->enableLogs = true;
 
   // Tell the system we want to catch the SIGUSR2 signals
   signal(SIGUSR2, signalHandler);
@@ -190,9 +191,13 @@ void Input::ParseCommandLine(int argc, char **argv) {
       IDEFIX_ERROR(msg);
     }
   }
+  this->enableLogs = enableLogs;
+  /*
   if(enableLogs) {
+    this->enableLogs = enableLogs;
     idfx::cout.enableLogFile();
   }
+  */
 }
 
 

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -24,6 +24,9 @@ class Input {
   // Constructor from a file
   Input (int, char ** );
   void ShowConfig();
+  
+  // flag if logging is to be done
+  bool enableLogs;
 
   // Accessor to input parameters
   // the parameters are always: BlockName, EntryName, ParameterNumber (starting from 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,15 @@ int main( int argc, char* argv[] ) {
     ///////////////////////////////
 
     Input input(argc, argv);
+
+    if(input.enableLogs) {
+      if(input.CheckEntry("Output","log_dir")>=0) {
+        idfx::logFileDir = input.Get<std::string>("Output", "log_dir", 0);
+      } else {
+        idfx::logFileDir = "./";
+      }
+      idfx::cout.enableLogFile();
+    }
     input.PrintLogo();
     idfx::cout << "Main: initialization stage." << std::endl;
 

--- a/src/output/xdmf.cpp
+++ b/src/output/xdmf.cpp
@@ -165,7 +165,7 @@ Xdmf::Xdmf(Input &input, DataBlock *datain) {
                                                                  cellsubsize[3]);
   */
   // Temporary storage on host for 3D arrays
-  this->vect3D = new float[nx1loc*nx2loc*nx3loc];
+  this->vect3D = new DUMP_DATATYPE[nx1loc*nx2loc*nx3loc];
 
   // fill the node_coord array
   DUMP_DATATYPE x1 = 0.0;


### PR DESCRIPTION
Often having a custom directory for dumping of log files is very useful to have the code files and executable separated from the location of data dumps. In this PR, this can be achieved by specifying `log_dir` in the `Output` block of `idefix.ini`. I remember that `PLUTO` already has such an option and it was quite helpful to me, personally as it prevented me to from accidentally overwriting the log files. I hope the developers find this a useful feature to have.