### PR TITLE
Simplify input file for DIMENSIONS < 3 setups

### DIFF
--- a/doc/source/reference/idefix.ini.rst
+++ b/doc/source/reference/idefix.ini.rst
@@ -16,7 +16,7 @@ allows for comments, which should start with ``#``.
 
 ``Grid`` section
 --------------------
-The grid section defines the grid total dimension. It consists of 3 entries ``X1-grid``, ``X2-grid`` and ``X3-grid``. Each entry defines the repartition of the grid points in the corresponding direction (the grid is always rectilinear).
+The grid section defines the grid total dimension. It consists of 3 entries ``X1-grid``, ``X2-grid`` (when DIMENSIONS>=2) and ``X3-grid`` (when DIMENSIONS=3). Each entry defines the repartition of the grid points in the corresponding direction (the grid is always rectilinear).
 Each entry defines a series of grid blocks which are concatenated along the direction. Each block in a direction can have a different spacing rule (uniform, log or stretched). The definition of the Grid entries is as follows
 
 +----------------------------+-------------------------+------------------------------+
@@ -332,8 +332,8 @@ this block is simply ignored.
 ------------------------
 
 This section describes the boundary conditions used by the code. There are 6 entries
-which need to be defined: ``X1-beg``, ``X2-beg``, ``X3-beg`` for the left boundaries in the direction X1, X2, X3,
-and ``X1-end``, ``X2-end``, ``X3-end`` for the right boundaries. Each boundary can be assigned the following types of conditions
+that need to be defined: ``X1-beg``, ``X2-beg``, ``X3-beg`` for the left boundaries in the direction X1, X2, X3,
+and ``X1-end``, ``X2-end``, ``X3-end`` for the right boundaries. ``X2`` boundaries are mandatory only when DIMENSIONS>=2 and ``X3`` when DIMENSIONS=3. Each boundary can be assigned the following types of conditions
 
 +----------------+------------------------------------------------------------------------------------------------------------------+
 | Boundary type  | Comment                                                                                                          |

--- a/src/dataBlock/planetarySystem/planetarySystem.cpp
+++ b/src/dataBlock/planetarySystem/planetarySystem.cpp
@@ -83,12 +83,16 @@ indirect term, with multiple planets that don't feel each others.");
     IDEFIX_ERROR("need to define a planet-to-primary mass ratio via planetToPrimary");
   }
 #if GEOMETRY == POLAR || GEOMETRY == CARTESIAN
-  if ((this->data->mygrid->xbeg[KDIR] == 0)
-      || (this->data->mygrid->xend[KDIR] == 0)) {
-    this->halfdisk = true;
-  } else {
+  #if DIMENSIONS == 3
+    if ((this->data->mygrid->xbeg[KDIR] == 0)
+        || (this->data->mygrid->xend[KDIR] == 0)) {
+      this->halfdisk = true;
+    } else {
+      this->halfdisk = false;
+    }
+  #else // DIMENSIONS == 3
     this->halfdisk = false;
-  }
+  #endif // DIMENSIONS == 3
 #elif GEOMETRY == SPHERICAL
   if ( (this->data->mygrid->xbeg[JDIR] == M_PI/2.0)
         || (this->data->mygrid->xend[JDIR] == M_PI/2.0)) {

--- a/src/gravity/laplacian.hpp
+++ b/src/gravity/laplacian.hpp
@@ -19,7 +19,14 @@ class DataBlock;
 class Laplacian {
  public:
   // Types of boundary which can be treated
-  enum LaplacianBoundaryType {internalgrav, periodic, nullgrad, nullpot, userdef, axis, origin};
+  enum LaplacianBoundaryType {internalgrav,
+                              periodic,
+                              nullgrad,
+                              nullpot,
+                              userdef,
+                              axis,
+                              origin,
+                              undefined};
 
   Laplacian() = default;
   Laplacian(DataBlock *, std::array<LaplacianBoundaryType,3>,

--- a/src/gravity/selfGravity.cpp
+++ b/src/gravity/selfGravity.cpp
@@ -42,7 +42,11 @@ void SelfGravity::Init(Input &input, DataBlock *datain) {
   }
 
   // Get the gravity-related boundary conditions
-  for(int dir = 0 ; dir < 3 ; dir++) {
+  for (int dir = 0 ; dir < 3 ; dir++) {
+    this->lbound[dir] = Laplacian::LaplacianBoundaryType::undefined;
+    this->rbound[dir] = Laplacian::LaplacianBoundaryType::undefined;
+  }
+  for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
     std::string label = std::string("boundary-X")+std::to_string(dir+1)+std::string("-beg");
     std::string boundary = input.Get<std::string>("SelfGravity",label,0);
 

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -55,7 +55,7 @@ Grid::Grid(Input &input) {
     npoints[dir] = 1;
     nghost[dir] = 0;
     std::string label = std::string("X")+std::to_string(dir+1)+std::string("-grid");
-    int numPatch = input.Get<int>("Grid",label,0);
+
 
     if(dir<DIMENSIONS) {
       #if ORDER < 4
@@ -64,6 +64,7 @@ Grid::Grid(Input &input) {
         nghost[dir] = 3;
       #endif
       npoints[dir] = 0;
+      int numPatch = input.Get<int>("Grid",label,0);
       for(int patch = 0; patch < numPatch ; patch++) {
         npoints[dir] += input.Get<int>("Grid",label,2+3*patch );
       }
@@ -73,7 +74,14 @@ Grid::Grid(Input &input) {
   for(int dir = 0 ; dir < 3 ; dir++) {
     np_tot[dir] = npoints[dir] + 2*nghost[dir];
     np_int[dir] = npoints[dir];
+    lbound[dir] = undefined;
+    rbound[dir] = undefined;
+  }
 
+  // Default boundary conditions on each axis
+
+
+  for(int dir = 0 ; dir < DIMENSIONS ; dir++) {
     std::string label = std::string("X")+std::to_string(dir+1)+std::string("-beg");
     std::string boundary = input.Get<std::string>("Boundary",label,0);
 
@@ -337,6 +345,9 @@ void Grid::ShowConfig() {
         case userdef:
           lboundString="userdef";
           break;
+        case undefined:
+          lboundString="undefined";
+          break;
         default:
           lboundString="unknown";
       }
@@ -362,6 +373,8 @@ void Grid::ShowConfig() {
         case userdef:
           rboundString="userdef";
           break;
+        case undefined:
+          lboundString="undefined";
         default:
           rboundString="unknown";
       }

--- a/src/gridHost.cpp
+++ b/src/gridHost.cpp
@@ -201,15 +201,15 @@ void GridHost::MakeGrid(Input &input) {
       // dir >= DIMENSIONS/ Init simple uniform grid
       for(int i = 0 ; i < np_tot[dir] ; i++) {
         // Initialize to default values
-        xstart[dir] = 0.0;
-        xend[dir] = 1.0;
+        xstart[dir] = -0.5;
+        xend[dir] = 0.5;
 
         this->xbeg[dir] = xstart[dir];
         this->xend[dir] = xend[dir];
-        dx[dir](i) = (xend[dir]-xstart[dir])/(np_int[dir]);
-        x[dir](i)=xstart[dir] + (i-nghost[dir]+HALF_F)*dx[dir](i);
-        xl[dir](i)=xstart[dir] + (i-nghost[dir])*dx[dir](i);
-        xr[dir](i)=xstart[dir] + (i-nghost[dir]+1)*dx[dir](i);
+        dx[dir](i) = 1.0;
+        x[dir](i)=0.0;
+        xl[dir](i)=-0.5;
+        xr[dir](i)=0.5;
       }
     }
   }

--- a/src/gridHost.cpp
+++ b/src/gridHost.cpp
@@ -50,17 +50,17 @@ void GridHost::MakeGrid(Input &input) {
 
   // Get grid parameters from input file, block [Grid]
   for(int dir = 0 ; dir < 3 ; dir++) {
-    std::string label = std::string("X")+std::to_string(dir+1)+std::string("-grid");
-    int numPatch = input.Get<int>("Grid",label,0);
-
-    xstart[dir] = input.Get<real>("Grid",label,1);
-    xend[dir] = input.Get<real>("Grid",label,4+(numPatch-1)*3);
-
-    this->xbeg[dir] = xstart[dir];
-    this->xend[dir] = xend[dir];
-
+    // These are extra dimensions that are not being used.
 
     if(dir<DIMENSIONS) {
+      std::string label = std::string("X")+std::to_string(dir+1)+std::string("-grid");
+      int numPatch = input.Get<int>("Grid",label,0);
+
+      xstart[dir] = input.Get<real>("Grid",label,1);
+      xend[dir] = input.Get<real>("Grid",label,4+(numPatch-1)*3);
+
+      this->xbeg[dir] = xstart[dir];
+      this->xend[dir] = xend[dir];
       // First, we fill cells for any non strecthed patch
       // Loop on all the patches
       int idxstart = nghost[dir];
@@ -200,6 +200,12 @@ void GridHost::MakeGrid(Input &input) {
     } else {
       // dir >= DIMENSIONS/ Init simple uniform grid
       for(int i = 0 ; i < np_tot[dir] ; i++) {
+        // Initialize to default values
+        xstart[dir] = 0.0;
+        xend[dir] = 1.0;
+
+        this->xbeg[dir] = xstart[dir];
+        this->xend[dir] = xend[dir];
         dx[dir](i) = (xend[dir]-xstart[dir])/(np_int[dir]);
         x[dir](i)=xstart[dir] + (i-nghost[dir]+HALF_F)*dx[dir](i);
         xl[dir](i)=xstart[dir] + (i-nghost[dir])*dx[dir](i);

--- a/src/idefix.hpp
+++ b/src/idefix.hpp
@@ -216,7 +216,7 @@ using IdfxFileHandler = FILE*;
 #endif
 
 // Types of boundary which can be treated
-enum BoundaryType { internal, periodic, reflective, outflow, shearingbox, axis, userdef};
+enum BoundaryType { internal, periodic, reflective, outflow, shearingbox, axis, userdef, undefined};
 enum BoundarySide { left, right};
 enum class SliceType {Cut, Average};
 

--- a/test/HD/FargoPlanet/setup.cpp
+++ b/test/HD/FargoPlanet/setup.cpp
@@ -43,7 +43,6 @@ void UserdefBoundary(Hydro *hydro, int dir, BoundarySide side, real t) {
   IdefixArray4D<real> Vc = hydro->Vc;
   auto *data = hydro->data;
   IdefixArray1D<real> x1 = data->x[IDIR];
-  IdefixArray1D<real> x3 = data->x[KDIR];
   if(dir==IDIR) {
     int ighost,ibeg,iend;
     if(side == left) {
@@ -56,7 +55,6 @@ void UserdefBoundary(Hydro *hydro, int dir, BoundarySide side, real t) {
         ibeg, iend,
         KOKKOS_LAMBDA (int k, int j, int i) {
           real R=x1(i);
-          real z=x3(k);
           real Vk = 1.0/sqrt(R);
 
           Vc(RHO,k,j,i) = Vc(RHO,k,j,2*ighost - i +1);
@@ -75,7 +73,6 @@ void UserdefBoundary(Hydro *hydro, int dir, BoundarySide side, real t) {
         ibeg, iend,
         KOKKOS_LAMBDA (int k, int j, int i) {
           real R=x1(i);
-          real z=x3(k);
           real Vk = 1.0/sqrt(R);
 
           Vc(RHO,k,j,i) = Vc(RHO,k,j,ighost);

--- a/test/HD/VSI/idefix.ini
+++ b/test/HD/VSI/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  1.0                 1024  l  3.0
 X2-grid    1  1.2707963267948965  512   u  1.8707963267948966
-X3-grid    1  0.0                 1     u  6.283185307179586
 
 [TimeIntegrator]
 CFL         0.8
@@ -22,8 +21,6 @@ X1-beg    userdef
 X1-end    outflow
 X2-beg    outflow
 X2-end    outflow
-X3-beg    periodic
-X3-end    periodic
 
 [Setup]
 epsilon    0.1

--- a/test/HD/ViscousDisk/idefix-rkl.ini
+++ b/test/HD/ViscousDisk/idefix-rkl.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  1.0                 64  u  3.0
 X2-grid    1  1.2707963267948965  64  u  1.8707963267948966
-X3-grid    1  0.0                 1   u  6.283185307179586
 
 [TimeIntegrator]
 CFL         0.5
@@ -23,8 +22,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    userdef
 X2-end    userdef
-X3-beg    periodic
-X3-end    periodic
 
 [Setup]
 epsilon    0.1

--- a/test/HD/ViscousDisk/idefix.ini
+++ b/test/HD/ViscousDisk/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  1.0                 64  u  3.0
 X2-grid    1  1.2707963267948965  64  u  1.8707963267948966
-X3-grid    1  0.0                 1   u  6.283185307179586
 
 [TimeIntegrator]
 CFL         0.5
@@ -23,8 +22,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    userdef
 X2-end    userdef
-X3-beg    periodic
-X3-end    periodic
 
 [Setup]
 epsilon    0.1

--- a/test/HD/ViscousFlowPastCylinder/idefix-rkl.ini
+++ b/test/HD/ViscousFlowPastCylinder/idefix-rkl.ini
@@ -1,9 +1,6 @@
 [Grid]
 X1-grid    1  1.0  128  l  10.0
-# X2-grid    3    -3.141592653589793  64   s+   -0.2  128    u   0.2  64 s-  3.141592653589793
-# X2-grid    1    -3.141592653589793  256  u    3.141592653589793
 X2-grid    1  0.0  64   u  6.28318530717958
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.4
@@ -21,8 +18,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    1.0

--- a/test/HD/ViscousFlowPastCylinder/idefix.ini
+++ b/test/HD/ViscousFlowPastCylinder/idefix.ini
@@ -1,9 +1,6 @@
 [Grid]
 X1-grid    1  1.0  128  l  10.0
-# X2-grid    3    -3.141592653589793  64   s+   -0.2  128    u   0.2  64 s-  3.141592653589793
-# X2-grid    1    -3.141592653589793  256  u    3.141592653589793
 X2-grid    1  0.0  64   u  6.28318530717958
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.4
@@ -21,8 +18,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    1.0

--- a/test/HD/sod-iso/idefix-hll.ini
+++ b/test/HD/sod-iso/idefix-hll.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod-iso/idefix-hllc-rk3.ini
+++ b/test/HD/sod-iso/idefix-hllc-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod-iso/idefix-hllc.ini
+++ b/test/HD/sod-iso/idefix-hllc.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod-iso/idefix-rk3.ini
+++ b/test/HD/sod-iso/idefix-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod-iso/idefix-tvdlf.ini
+++ b/test/HD/sod-iso/idefix-tvdlf.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod-iso/idefix.ini
+++ b/test/HD/sod-iso/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod/idefix-hll.ini
+++ b/test/HD/sod/idefix-hll.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.4
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod/idefix-hllc-rk3.ini
+++ b/test/HD/sod/idefix-hllc-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.4
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod/idefix-hllc.ini
+++ b/test/HD/sod/idefix-hllc.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.4
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod/idefix-rk3.ini
+++ b/test/HD/sod/idefix-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.4
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod/idefix-tvdlf.ini
+++ b/test/HD/sod/idefix-tvdlf.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.4
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/sod/idefix.ini
+++ b/test/HD/sod/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  500  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.4
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    outflow
-X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.1

--- a/test/HD/thermalDiffusion/idefix-rkl.ini
+++ b/test/HD/thermalDiffusion/idefix-rkl.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  -0.5  500  u  0.5
-X2-grid    1  0.0   1    u  1.0
-X3-grid    1  0.0   1    u  1.0
 
 [TimeIntegrator]
 CFL        0.8
@@ -19,10 +17,6 @@ amplitude    1e-6
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 analysis    0.01

--- a/test/HD/thermalDiffusion/idefix-rkl.ini
+++ b/test/HD/thermalDiffusion/idefix-rkl.ini
@@ -1,5 +1,7 @@
 [Grid]
 X1-grid    1  -0.5  500  u  0.5
+X2-grid    1  0.0   1    u  1.0
+X3-grid    1  0.0   1    u  1.0
 
 [TimeIntegrator]
 CFL        0.8
@@ -17,6 +19,10 @@ amplitude    1e-6
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
+X2-beg    periodic
+X2-end    periodic
+X3-beg    periodic
+X3-end    periodic
 
 [Output]
 analysis    0.01

--- a/test/HD/thermalDiffusion/idefix.ini
+++ b/test/HD/thermalDiffusion/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  -0.5  500  u  0.5
-X2-grid    1  0.0   1    u  1.0
-X3-grid    1  0.0   1    u  1.0
 
 [TimeIntegrator]
 CFL        0.8
@@ -19,10 +17,6 @@ amplitude    1e-6
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 analysis    0.01

--- a/test/HD/thermalDiffusion/idefix.ini
+++ b/test/HD/thermalDiffusion/idefix.ini
@@ -1,5 +1,7 @@
 [Grid]
 X1-grid    1  -0.5  500  u  0.5
+X2-grid    1  0.0   1    u  1.0
+X3-grid    1  0.0   1    u  1.0
 
 [TimeIntegrator]
 CFL        0.8
@@ -17,6 +19,10 @@ amplitude    1e-6
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
+X2-beg    periodic
+X2-end    periodic
+X3-beg    periodic
+X3-end    periodic
 
 [Output]
 analysis    0.01

--- a/test/MHD/AmbipolarCshock/idefix-rkl.ini
+++ b/test/MHD/AmbipolarCshock/idefix-rkl.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  100  u  50.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.9
@@ -17,10 +15,6 @@ csiso        constant  0.1
 [Boundary]
 X1-beg    userdef
 X1-end    userdef
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    100.0

--- a/test/MHD/AmbipolarWind/idefix.ini
+++ b/test/MHD/AmbipolarWind/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  1.0  768  l   100.0
 X2-grid    3  0.0  64   s+  1.28   96  u  1.861592653589  64  s-  3.141592653589793
-X3-grid    1  0.0  0    u   1.0
 
 [TimeIntegrator]
 CFL            0.9
@@ -25,8 +24,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    axis
 X2-end    axis
-X3-beg    periodic
-X3-end    periodic
 
 [Setup]
 epsilon                0.05

--- a/test/MHD/MTI/idefix-rkl.ini
+++ b/test/MHD/MTI/idefix-rkl.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.  32  u  0.1
 X2-grid    1  0.  32  u  0.1
-X3-grid    1  0.  1   u  1.
 
 [TimeIntegrator]
 CFL            0.7
@@ -24,8 +23,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    userdef
 X2-end    userdef
-X3-beg    userdef
-X3-end    userdef
 
 [Setup]
 ksi         5e-4

--- a/test/MHD/MTI/idefix-sl.ini
+++ b/test/MHD/MTI/idefix-sl.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.  32  u  0.1
 X2-grid    1  0.  32  u  0.1
-X3-grid    1  0.  1   u  1.
 
 [TimeIntegrator]
 CFL            0.7
@@ -24,8 +23,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    userdef
 X2-end    userdef
-X3-beg    userdef
-X3-end    userdef
 
 [Setup]
 ksi         5e-4

--- a/test/MHD/MTI/idefix.ini
+++ b/test/MHD/MTI/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.  32  u  0.1
 X2-grid    1  0.  32  u  0.1
-X3-grid    1  0.  1   u  1.
 
 [TimeIntegrator]
 CFL            0.7
@@ -24,8 +23,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    userdef
 X2-end    userdef
-X3-beg    userdef
-X3-end    userdef
 
 [Setup]
 ksi         5e-4

--- a/test/MHD/OrszagTang/idefix-hll.ini
+++ b/test/MHD/OrszagTang/idefix-hll.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -17,8 +16,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix-hlld-arithmetic.ini
+++ b/test/MHD/OrszagTang/idefix-hlld-arithmetic.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -18,8 +17,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix-hlld-hll.ini
+++ b/test/MHD/OrszagTang/idefix-hlld-hll.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -18,8 +17,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix-hlld-hlld.ini
+++ b/test/MHD/OrszagTang/idefix-hlld-hlld.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -18,8 +17,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix-hlld-uct0.ini
+++ b/test/MHD/OrszagTang/idefix-hlld-uct0.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -18,8 +17,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix-hlld.ini
+++ b/test/MHD/OrszagTang/idefix-hlld.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -17,8 +16,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix-tvdlf.ini
+++ b/test/MHD/OrszagTang/idefix-tvdlf.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -17,8 +16,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/OrszagTang/idefix.ini
+++ b/test/MHD/OrszagTang/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
 X2-grid    1  0.0  128  u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.6
@@ -17,8 +16,6 @@ X1-beg    periodic
 X1-end    periodic
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.5

--- a/test/MHD/ResistiveAlfvenWave/idefix-rkl.ini
+++ b/test/MHD/ResistiveAlfvenWave/idefix-rkl.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.9
@@ -16,10 +14,6 @@ resistivity    rkl  constant  0.05
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 # vtk       0.1

--- a/test/MHD/ResistiveAlfvenWave/idefix.ini
+++ b/test/MHD/ResistiveAlfvenWave/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  128  u  1.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.9
@@ -16,10 +14,6 @@ resistivity    explicit  constant  0.05
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 # vtk       0.1

--- a/test/MHD/RotorCartesian/idefix.ini
+++ b/test/MHD/RotorCartesian/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  -0.5  512  u  0.5
 X2-grid    1  -0.5  512  u  0.5
-X3-grid    1  0.0   1    u  1.0
 
 [TimeIntegrator]
 CFL            0.2
@@ -19,8 +18,6 @@ X1-beg    outflow
 X1-end    outflow
 X2-beg    outflow
 X2-end    outflow
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 vtk    0.01  -1  single_file

--- a/test/MHD/RotorPolar/idefix.ini
+++ b/test/MHD/RotorPolar/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
 X1-grid    1  0.05  256   u  0.5
 X2-grid    1  0.0   1024  u  6.283185307179586
-X3-grid    1  0.0   1     u  1.0
 
 [TimeIntegrator]
 CFL            0.2
@@ -19,8 +18,6 @@ X1-beg    userdef
 X1-end    outflow
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Output]
 uservar    Vx    Vy

--- a/test/MHD/sod-iso/idefix-hll.ini
+++ b/test/MHD/sod-iso/idefix-hll.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod-iso/idefix-hlld-rk3.ini
+++ b/test/MHD/sod-iso/idefix-hlld-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod-iso/idefix-hlld.ini
+++ b/test/MHD/sod-iso/idefix-hlld.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod-iso/idefix-rk3.ini
+++ b/test/MHD/sod-iso/idefix-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod-iso/idefix-tvdlf.ini
+++ b/test/MHD/sod-iso/idefix-tvdlf.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod-iso/idefix.ini
+++ b/test/MHD/sod-iso/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ csiso     constant  1.0
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod/idefix-hll.ini
+++ b/test/MHD/sod/idefix-hll.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL            0.8
@@ -18,10 +16,6 @@ gamma     1.66666666666667
 # not used
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod/idefix-hlld-rk3.ini
+++ b/test/MHD/sod/idefix-hlld-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL            0.8
@@ -18,10 +16,6 @@ gamma     1.66666666666667
 # not used
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod/idefix-hlld.ini
+++ b/test/MHD/sod/idefix-hlld.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL            0.8
@@ -18,10 +16,6 @@ gamma     1.66666666666667
 # not used
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod/idefix-rk3.ini
+++ b/test/MHD/sod/idefix-rk3.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.66666666666667
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod/idefix-tvdlf.ini
+++ b/test/MHD/sod/idefix-tvdlf.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL            0.8
@@ -18,10 +16,6 @@ gamma     1.66666666666667
 # not used
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/MHD/sod/idefix.ini
+++ b/test/MHD/sod/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  800  u  100.0
-X2-grid    1  0.0  1    u  1.0
-X3-grid    1  0.0  1    u  1.0
 
 [TimeIntegrator]
 CFL         0.8
@@ -16,10 +14,6 @@ gamma     1.66666666666667
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    10.0

--- a/test/Planet/Planet3Body/idefix.ini
+++ b/test/Planet/Planet3Body/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
-X1-grid    1  0.042     64  u  2.3
-X2-grid    1  0.0       32  u  6.283185307179586
-X3-grid    1  -0.00125  1   u  0.00125
+X1-grid    1  0.042  64  u  2.3
+X2-grid    1  0.0    32  u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.5
@@ -26,8 +25,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Setup]
 sigma0          0.001

--- a/test/Planet/PlanetMigration2D/idefix.ini
+++ b/test/Planet/PlanetMigration2D/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
-X1-grid    1  0.42     192  u  2.14
-X2-grid    1  0.0      768  u  6.283185307179586
-X3-grid    1  -0.0125  1    u  0.0125
+X1-grid    1  0.42  192  u  2.14
+X2-grid    1  0.0   768  u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.5
@@ -29,8 +28,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Setup]
 sigma0          0.001

--- a/test/Planet/PlanetPlanetRK42D/idefix.ini
+++ b/test/Planet/PlanetPlanetRK42D/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
-X1-grid    1  0.42     96   u  2.14
-X2-grid    1  0.0      384  u  6.283185307179586
-X3-grid    1  -0.0125  1    u  0.0125
+X1-grid    1  0.42  96   u  2.14
+X2-grid    1  0.0   384  u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.5
@@ -24,8 +23,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Setup]
 sigma0          0.001

--- a/test/Planet/PlanetSpiral2D/idefix.ini
+++ b/test/Planet/PlanetSpiral2D/idefix.ini
@@ -1,7 +1,6 @@
 [Grid]
-X1-grid    1  0.42     128  u  2.14
-X2-grid    1  0.0      512  u  6.283185307179586
-X3-grid    1  -0.0125  1    u  0.0125
+X1-grid    1  0.42  128  u  2.14
+X2-grid    1  0.0   512  u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.5
@@ -28,8 +27,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Setup]
 sigma0          1.0

--- a/test/Planet/PlanetsIsActiveRK52D/idefix-rk4.ini
+++ b/test/Planet/PlanetsIsActiveRK52D/idefix-rk4.ini
@@ -1,7 +1,6 @@
 [Grid]
-X1-grid    1  0.42     48   u  2.14
-X2-grid    1  0.0      192  u  6.283185307179586
-X3-grid    1  -0.0125  1    u  0.0125
+X1-grid    1  0.42  48   u  2.14
+X2-grid    1  0.0   192  u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.5
@@ -24,8 +23,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Setup]
 sigma0          0.001

--- a/test/Planet/PlanetsIsActiveRK52D/idefix-rk5.ini
+++ b/test/Planet/PlanetsIsActiveRK52D/idefix-rk5.ini
@@ -1,7 +1,6 @@
 [Grid]
-X1-grid    1  0.42     48   u  2.14
-X2-grid    1  0.0      192  u  6.283185307179586
-X3-grid    1  -0.0125  1    u  0.0125
+X1-grid    1  0.42  48   u  2.14
+X2-grid    1  0.0   192  u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.5
@@ -24,8 +23,6 @@ X1-beg    userdef
 X1-end    userdef
 X2-beg    periodic
 X2-end    periodic
-X3-beg    outflow
-X3-end    outflow
 
 [Setup]
 sigma0          0.001

--- a/test/SelfGravity/DustyCollapse/idefix.ini
+++ b/test/SelfGravity/DustyCollapse/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.1  4096  l  3e4
-X2-grid    1  0    64    u  3.14159265358979
-X3-grid    1  0    64    u  6.28318530717958
 
 [TimeIntegrator]
 CFL         0.2
@@ -25,18 +23,10 @@ targetError        1e-7
 maxIter            10000
 boundary-X1-beg    nullgrad
 boundary-X1-end    nullpot
-boundary-X2-beg    axis
-boundary-X2-end    axis
-boundary-X3-beg    periodic
-boundary-X3-end    periodic
 
 [Boundary]
 X1-beg    outflow
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 dmp        1

--- a/test/SelfGravity/JeansInstability/idefix-cg.ini
+++ b/test/SelfGravity/JeansInstability/idefix-cg.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  1000  u  10.0
-X2-grid    1  0.0  100   u  10.0
-X3-grid    1  0.0  100   u  10.0
 
 [TimeIntegrator]
 CFL            0.8
@@ -24,18 +22,10 @@ solver             CG
 targetError        1e-6
 boundary-X1-beg    periodic
 boundary-X1-end    periodic
-boundary-X2-beg    periodic
-boundary-X2-end    periodic
-boundary-X3-beg    periodic
-boundary-X3-end    periodic
 
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    0.1

--- a/test/SelfGravity/JeansInstability/idefix.ini
+++ b/test/SelfGravity/JeansInstability/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  0.0  1000  u  10.0
-X2-grid    1  0.0  100   u  10.0
-X3-grid    1  0.0  100   u  10.0
 
 [TimeIntegrator]
 CFL            0.8
@@ -24,18 +22,10 @@ targetError        1e-6
 # skip               2
 boundary-X1-beg    periodic
 boundary-X1-end    periodic
-boundary-X2-beg    periodic
-boundary-X2-end    periodic
-boundary-X3-beg    periodic
-boundary-X3-end    periodic
 
 [Boundary]
 X1-beg    periodic
 X1-end    periodic
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 vtk    0.1

--- a/test/SelfGravity/UniformCollapse/idefix.ini
+++ b/test/SelfGravity/UniformCollapse/idefix.ini
@@ -1,7 +1,5 @@
 [Grid]
 X1-grid    1  .01  100  l  1000.
-X2-grid    1  0.0  20   u  3.141592653589793
-X3-grid    1  0.0  20   u  6.283185307179586
 
 [TimeIntegrator]
 CFL            0.8
@@ -25,18 +23,10 @@ skip               5
 targetError        1e-6
 boundary-X1-beg    origin
 boundary-X1-end    nullpot
-boundary-X2-beg    periodic
-boundary-X2-end    periodic
-boundary-X3-beg    periodic
-boundary-X3-end    periodic
 
 [Boundary]
 X1-beg    userdef
 X1-end    outflow
-X2-beg    periodic
-X2-end    periodic
-X3-beg    periodic
-X3-end    periodic
 
 [Output]
 analysis    10.


### PR DESCRIPTION
Historically, Idefix has always required the user to specify the Grid and the boundary conditions in the 3 spatial directions regardless of the DIMENSIONS parameters. This has led to confusions a number of times for newcomers, since this is actually never used in practice.

This PR attempts at fixing this: we no longer require the Grid and Boundary conditions to be specified in the directions >= DIMENSIONS.

Tests with DIMENSIONS<3 have been adjusted accordingly.