### PR TITLE
STY: locally disable linting around `#include <filesystem>`

### DIFF
--- a/src/output/xdmf.cpp
+++ b/src/output/xdmf.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <iomanip>
 #if __has_include(<filesystem>)
-  #include <filesystem>
+  #include <filesystem> // NOLINT [build/c++17]
   namespace fs = std::filesystem;
 #elif __has_include(<experimental/filesystem>)
   #include <experimental/filesystem>


### PR DESCRIPTION
quick follow up to #279 (apparently I missed a spot)