### PR TITLE
Update to numpy 2+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
         - F # pyflakes
         - B # flake8-bugbear
         - I # isort
+        - NPY # numpy-specific rules
 
   - repo: https://github.com/neutrinoceros/inifix
     rev: v5.0.2

--- a/pytools/idfx_io.py
+++ b/pytools/idfx_io.py
@@ -29,7 +29,7 @@ class IdfxFileField(object):
         dims = []
         for dim in range(self.ndims):
             dims.append(int.from_bytes(fh.read(INT_SIZE), byteorder))
-        ntot = int(np.product(dims))
+        ntot = int(np.prod(dims))
         raw = struct.unpack(str(ntot) + "d", fh.read(DOUBLE_SIZE * ntot))
         self.array = np.asarray(raw).reshape(dims[::-1])
 


### PR DESCRIPTION
`idfx_io.py` used `np.product` which is deprecated in numpy >= 2.0 (https://numpy.org/devdocs/numpy_2_0_migration_guide.html). Replaced by `np.prod`.