### PR TITLE
Adding SG potential to idfx files

### DIFF
--- a/src/dataBlock/dumpToFile.cpp
+++ b/src/dataBlock/dumpToFile.cpp
@@ -93,13 +93,13 @@ void DataBlock::DumpToFile(std::string filebase)  {
   WriteVariable(fileHdl, 4, dims, fieldName, locVc.data());
 
   if (this->gravity->haveSelfGravityPotential) {
-    IdefixArray3D<real>::HostMirror localPot = Kokkos::create_mirror_view(this->gravity->phiP);
-    Kokkos::deep_copy(localPot, this->gravity->phiP);
+    IdefixArray3D<real>::HostMirror locPot = Kokkos::create_mirror_view(this->gravity->phiP);
+    Kokkos::deep_copy(locPot, this->gravity->phiP);
 
     dims[3] = 1;
     std::snprintf(fieldName,NAMESIZE,"Pot");
 
-    WriteVariable(fileHdl, 4, dims, fieldName, localPot.data());
+    WriteVariable(fileHdl, 4, dims, fieldName, locPot.data());
   }
 
   // Write Flux

--- a/src/dataBlock/dumpToFile.cpp
+++ b/src/dataBlock/dumpToFile.cpp
@@ -92,6 +92,16 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
   WriteVariable(fileHdl, 4, dims, fieldName, locVc.data());
 
+  if (this->gravity->haveSelfGravityPotential) {
+    IdefixArray3D<real>::HostMirror localPot = Kokkos::create_mirror_view(this->gravity->phiP);
+    Kokkos::deep_copy(localPot, this->gravity->phiP);
+
+    dims[3] = 1;
+    std::snprintf(fieldName,NAMESIZE,"Pot");
+
+    WriteVariable(fileHdl, 4, dims, fieldName, localPot.data());
+  }
+
   // Write Flux
   /*
   nx1=this->np_tot[IDIR];


### PR DESCRIPTION
This PR adds the gravitational potential to the idfx files when self-gravity is enabled, for debug purposes.
This is complementary to #245 and is not redundant as idfx files also include the ghost regions.