### PR TITLE
TST: handle a deprecation warning from numpy 1.25

### DIFF
--- a/test/MHD/AmbipolarCshock/python/testidefix.py
+++ b/test/MHD/AmbipolarCshock/python/testidefix.py
@@ -72,7 +72,7 @@ r.set_initial_value(DSim[iref],x[iref])
 Dth=np.zeros(x.shape)
 for i in range(x.size):
     r.set_initial_value(DSim[iref],x[iref])
-    Dth[i]=r.integrate(x[i])
+    Dth[i]=r.integrate(x[i]).item()
     #print("Dth[%d]=%g"%(i,Dth[i]))
 
 bTh=np.sqrt(b0**2+2*A**2*(Dth-1)*(1/Dth-1/M**2))

--- a/test/MHD/AmbipolarCshock3D/python/testidefix.py
+++ b/test/MHD/AmbipolarCshock3D/python/testidefix.py
@@ -75,7 +75,7 @@ r.set_initial_value(DSim[iref],x[iref])
 Dth=np.zeros(x.shape)
 for i in range(x.size):
     r.set_initial_value(DSim[iref],x[iref])
-    Dth[i]=r.integrate(x[i])
+    Dth[i]=r.integrate(x[i]).item()
     #print("Dth[%d]=%g"%(i,Dth[i]))
 
 bTh=np.sqrt(b0**2+2*A**2*(Dth-1)*(1/Dth-1/M**2))


### PR DESCRIPTION
Avoid the following warning (and associated future breakage)
```
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  Dth[i]=r.integrate(x[i])
```