### PR TITLE
MNT: give a unique name to documentation build workflows

### DIFF
--- a/.github/workflows/idefix-ci-doc.yml
+++ b/.github/workflows/idefix-ci-doc.yml
@@ -1,4 +1,4 @@
-name: Idefix CIs
+name: Build the docs
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Follow up to #305. Navigating https://github.com/idefix-code/idefix/actions/workflows is confusing if names are not unique.