### PR TITLE
Implement Collisionless heat flux into the Braginskii module

### DIFF
--- a/doc/source/modules/braginskii.rst
+++ b/doc/source/modules/braginskii.rst
@@ -4,7 +4,7 @@ Braginskii module
 ===================
 
 Equations solved and methods
----------------------------
+----------------------------
 
 The ``Braginskii`` module implements the anisotropic heat and momentum fluxes specific
 to weakly collisional, magnetised plasma like the intracluster medium
@@ -72,18 +72,69 @@ of the Braginskii heat flux and viscosity.
 
 .. _braginskiiParameterSection:
 
+
+Saturation with collisionless heat flux
+---------------------------------------
+
+The ``Braginskii`` module can include a collisionless saturation of the Braginskii heat flux.
+The heat flux is then computed as follows:
+
+:math:`q = \alpha (q_B + q_\perp) + (1-\alpha)\beta*p*v`,
+
+where :math:`\alpha \in [0,1]` controls the transition between the Braginskii heat flux and the collisionless heat flux
+and :math:`\beta` controls the amplitude of the collisionless heat flux (typically :math:`\beta \in [1,4]`, see Hollweg 1976).
+
+.. note::
+    As a result, even with :math:`\kappa_\perp = 0`, the heat flux is no longer necessarilly strictly aligned with the magnetic field.
+.. note::
+    The collisionless heat flux is a hyperbolic term and the diffusion coefficient is set proportional to :math:`\alpha`.
+.. note::
+    If selected, slope limiters are also used in the collisionless flux, where an upwind scheme has been implemented for stability.
+.. note::
+    This saturation has been thought to be used mostly using the uerdef function that takes four arrays as input and is enrolled through
+    ``data.hydro->bragThermalDiffusion->EnrollClessThermalDiffusivity()``
+
 Main parameters of the module
 -----------------------------
 
 The ``Braginskii`` module can be enabled adding one or two lines in the ``[Hydro]`` section
-starting with the keyword
-`bragTDiffusion` or/and *bragViscosity*. The following table summarises the different options
+starting with the keyword `bragTDiffusion` or/and *bragViscosity*. The following tables summarise the different options
 associated to the activation of the Braginskii module:
 
 +--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
 | Column |  Entry name           | Parameter type          | Comment                                                                               |
 +========+=======================+=========================+=======================================================================================+
-| 0      |  bragModule           | string                  | | Activates Braginskii diffusion. Can be ``bragTDiffusion`` or ``bragViscosity``.     |
+| 0      |  bragTDiffusion       | string                  | | Activates Braginskii thermal diffusion.                                             |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 1      | integration           | string                  | | Specifies the type of scheme to be used to integrate the parabolic term.            |
+|        |                       |                         | | Can be ``rkl`` or ``explicit``.                                                     |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 2      | slope limiter         | string                  | | Choose the type of limiter to be used to compute anisotropic transverse flux terms. |
+|        |                       |                         | | Can be ``mc``, ``vanleer`` or ``nolimiter``.                                        |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 3      | saturation mode       | string                  | | Include or not collisionless saturation. Can be ``nosat`` or ``wcless``.            |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 4      | diffusivity type      | string                  | | Specifies the type of diffusivity wanted. Can be ``constant`` or ``userdef``.       |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 5      | parallel diffusivity  | real                    | | Mandatory if the diffusivity type is ``constant``. Not needed otherwise.            |
+|        |                       |                         | | Value of the parallel diffusivity. Should be a real number.                         |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 6      | normal diffusivity    | real                    | | When bragModule ``bragTDiffusion`` and diffusivity type ``constant``,               |
+|        |                       |                         | | value of the normal diffusivity. Should be a real number.                           |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 7      | alpha collisionless   | real                    | | If the diffusivity type is ``constant`` and saturation is ``wcless``.               |
+|        |                       |                         | | Set to 1 if not provided.                                                           |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| 8      | beta collisionless    | real                    | | If the diffusivity type is ``constant`` and saturation is ``wcless``.               |
+|        |                       |                         | | Set to 0 if not provided.                                                           |
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+
+for the *bragViscosity*:
+
++--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
+| Column |  Entry name           | Parameter type          | Comment                                                                               |
++========+=======================+=========================+=======================================================================================+
+| 0      |  bragViscosity        | string                  | | Activates Braginskii viscosity.                                                     |
 +--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
 | 1      | integration           | string                  | | Specifies the type of scheme to be used to integrate the parabolic term.            |
 |        |                       |                         | | Can be ``rkl`` or ``explicit``.                                                     |
@@ -101,7 +152,7 @@ associated to the activation of the Braginskii module:
 +--------+-----------------------+-------------------------+---------------------------------------------------------------------------------------+
 
 Numerical checks
----------------
+----------------
 
 In Cartesian geometry, the ``Braginskii`` module has been tested with many setups
 and in all configurations of magnetic polarisation:
@@ -119,3 +170,5 @@ The same goes for the anisotropic heat flux in Cylindrical/Polar geometry while
 the anisotropic viscosity has *never* been tested in this geometry.
 In spherical geometry, both ``Braginskii`` operators have been partially validated
 (diffusion along the polar axis has not been directly tested).
+
+The collisionless saturation has been tested in 1D and 2D spherical geometry.

--- a/doc/source/modules/braginskii.rst
+++ b/doc/source/modules/braginskii.rst
@@ -91,7 +91,7 @@ and :math:`\beta` controls the amplitude of the collisionless heat flux (typical
 .. note::
     If selected, slope limiters are also used in the collisionless flux, where an upwind scheme has been implemented for stability.
 .. note::
-    This saturation has been thought to be used mostly using the uerdef function that takes four arrays as input and is enrolled through
+    This saturation has been thought to be used mostly using the userdef function that takes four arrays as input and is enrolled through
     ``data.hydro->bragThermalDiffusion->EnrollClessThermalDiffusivity()``
 
 Main parameters of the module

--- a/doc/source/modules/braginskii.rst
+++ b/doc/source/modules/braginskii.rst
@@ -76,7 +76,7 @@ of the Braginskii heat flux and viscosity.
 Saturation with collisionless heat flux
 ---------------------------------------
 
-The ``Braginskii`` module can include a collisionless saturation of the Braginskii heat flux.
+The ``Braginskii`` module can include a collisionless saturation of the Braginskii heat flux, typically due to supra-thermal electrons.
 The heat flux is then computed as follows:
 
 :math:`q = \alpha (q_B + q_\perp) + (1-\alpha)\beta*p*v`,
@@ -91,8 +91,7 @@ and :math:`\beta` controls the amplitude of the collisionless heat flux (typical
 .. note::
     If selected, slope limiters are also used in the collisionless flux, where an upwind scheme has been implemented for stability.
 .. note::
-    This saturation has been thought to be used mostly using the userdef function that takes four arrays as input and is enrolled through
-    ``data.hydro->bragThermalDiffusion->EnrollClessThermalDiffusivity()``
+    This saturation has been thought to be used mostly using the userdef function that takes four userdef arrays as input.
 
 Main parameters of the module
 -----------------------------

--- a/src/fluid/braginskii/bragThermalDiffusion.cpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.cpp
@@ -27,11 +27,17 @@ void BragThermalDiffusion::ShowConfig() {
   } else if (status.status==UserDefFunction) {
     idfx::cout << "Braginskii Thermal Diffusion: ENABLED with user-defined diffusivity function."
                    << std::endl;
-    if(!diffusivityFunc) {
+    if(!bragDiffusivityFunc) {
       IDEFIX_ERROR("No braginskii thermal diffusion function has been enrolled");
     }
+  } else if (status.status==CollisionLess) {
+    idfx::cout << "CollisionLess / Braginskii Thermal Diffusion: ENABLED with user-defined "
+      "diffusivity function."<< std::endl;
+    if(!clessDiffusivityFunc) {
+      IDEFIX_ERROR("No collisionless / Braginskii thermal diffusion function has been enrolled");
+    }
   } else {
-    IDEFIX_ERROR("Unknown braginskii thermal diffusion mode");
+    IDEFIX_ERROR("Unknown Braginskii thermal diffusion mode");
   }
   if(status.isExplicit) {
     idfx::cout << "Braginskii Thermal Diffusion: uses an explicit time integration." << std::endl;
@@ -46,12 +52,20 @@ void BragThermalDiffusion::ShowConfig() {
   }
 }
 
-void BragThermalDiffusion::EnrollBragThermalDiffusivity(FourArrayDiffusivityFunc myFunc) {
+void BragThermalDiffusion::EnrollBragThermalDiffusivity(TwoArrayDiffusivityFunc myFunc) {
   if(this->status.status != UserDefFunction) {
     IDEFIX_WARNING("Braginskii thermal diffusivity enrollment requires Hydro/BragThermalDiffusion "
                  "to be set to userdef in .ini file");
   }
-  this->diffusivityFunc = myFunc;
+  this->bragDiffusivityFunc = myFunc;
+}
+
+void BragThermalDiffusion::EnrollClessThermalDiffusivity(FourArrayDiffusivityFunc myFunc) {
+  if(this->status.status != UserDefFunction) {
+    IDEFIX_WARNING("Collisionless/Braginskii thermal diffusivity enrollment requires "
+           "Hydro/BragThermalDiffusion to be set to collisionless in .ini file");
+  }
+  this->clessDiffusivityFunc = myFunc;
 }
 
 void BragThermalDiffusion::AddBragDiffusiveFlux(int dir, const real t,

--- a/src/fluid/braginskii/bragThermalDiffusion.cpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.cpp
@@ -19,7 +19,6 @@
 #include "eos.hpp"
 
 
-
 void BragThermalDiffusion::ShowConfig() {
   if(status.status==Constant) {
     idfx::cout << "Braginskii Thermal Diffusion: ENABLED with constant diffusivity kpar="
@@ -27,7 +26,7 @@ void BragThermalDiffusion::ShowConfig() {
   } else if (status.status==UserDefFunction) {
     idfx::cout << "Braginskii Thermal Diffusion: ENABLED with user-defined diffusivity function."
                    << std::endl;
-    if(!bragDiffusivityFunc && !clessDiffusivityFunc) {
+    if(!bragDiffusivityFunc) {
       IDEFIX_ERROR("No braginskii thermal diffusion function has been enrolled");
     }
   } else {
@@ -57,20 +56,12 @@ void BragThermalDiffusion::ShowConfig() {
   }
 }
 
-void BragThermalDiffusion::EnrollBragThermalDiffusivity(TwoArrayDiffusivityFunc myFunc) {
+void BragThermalDiffusion::EnrollBragThermalDiffusivity(BragDiffusivityFunc myFunc) {
   if(this->status.status != UserDefFunction) {
     IDEFIX_WARNING("Braginskii thermal diffusivity enrollment requires Hydro/BragThermalDiffusion "
                    "to be set to userdef in .ini file");
   }
   this->bragDiffusivityFunc = myFunc;
-}
-
-void BragThermalDiffusion::EnrollClessThermalDiffusivity(FourArrayDiffusivityFunc myFunc) {
-  if(this->status.status != UserDefFunction) {
-    IDEFIX_WARNING("Collisionless/Braginskii thermal diffusivity enrollment requires "
-           "Hydro/BragThermalDiffusion to be set to userdef in .ini file");
-  }
-  this->clessDiffusivityFunc = myFunc;
 }
 
 void BragThermalDiffusion::AddBragDiffusiveFlux(int dir, const real t,

--- a/src/fluid/braginskii/bragThermalDiffusion.cpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.cpp
@@ -46,7 +46,7 @@ void BragThermalDiffusion::ShowConfig() {
   }
 }
 
-void BragThermalDiffusion::EnrollBragThermalDiffusivity(BragDiffusivityFunc myFunc) {
+void BragThermalDiffusion::EnrollBragThermalDiffusivity(FourArrayDiffusivityFunc myFunc) {
   if(this->status.status != UserDefFunction) {
     IDEFIX_WARNING("Braginskii thermal diffusivity enrollment requires Hydro/BragThermalDiffusion "
                  "to be set to userdef in .ini file");

--- a/src/fluid/braginskii/bragThermalDiffusion.cpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.cpp
@@ -42,18 +42,18 @@ void BragThermalDiffusion::ShowConfig() {
     IDEFIX_ERROR("Unknown time integrator for braginskii thermal diffusion.");
   }
   if(haveSlopeLimiter) {
-    if(haveMonotizedCentral) {
-      idfx::cout << "Braginskii Thermal Diffusion: uses the monotonized central slope limiter." << std::endl;
-    }
-    else if(haveVanLeer) {
+    if(haveMonotonizedCentral) {
+      idfx::cout << "Braginskii Thermal Diffusion: "
+      "uses the monotonized central slope limiter." << std::endl;
+    } else if(haveVanLeer) {
       idfx::cout << "Braginskii Thermal Diffusion: uses the van Leer slope limiter." << std::endl;
-    }
-    else {
+    } else {
       IDEFIX_ERROR("Unknown slope limiter for braginskii thermal diffusion.");
     }
   }
   if(includeCollisionlessTD) {
-     idfx::cout << "Braginskii Thermal Diffusion: saturation with collisionless flux is enabled." << std::endl;
+     idfx::cout << "Braginskii Thermal Diffusion: saturation"
+     " with collisionless flux is enabled." << std::endl;
   }
 }
 

--- a/src/fluid/braginskii/bragThermalDiffusion.cpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.cpp
@@ -27,14 +27,8 @@ void BragThermalDiffusion::ShowConfig() {
   } else if (status.status==UserDefFunction) {
     idfx::cout << "Braginskii Thermal Diffusion: ENABLED with user-defined diffusivity function."
                    << std::endl;
-    if(!bragDiffusivityFunc) {
+    if(!bragDiffusivityFunc && !clessDiffusivityFunc) {
       IDEFIX_ERROR("No braginskii thermal diffusion function has been enrolled");
-    }
-  } else if (status.status==CollisionLess) {
-    idfx::cout << "CollisionLess / Braginskii Thermal Diffusion: ENABLED with user-defined "
-      "diffusivity function."<< std::endl;
-    if(!clessDiffusivityFunc) {
-      IDEFIX_ERROR("No collisionless / Braginskii thermal diffusion function has been enrolled");
     }
   } else {
     IDEFIX_ERROR("Unknown Braginskii thermal diffusion mode");
@@ -50,12 +44,15 @@ void BragThermalDiffusion::ShowConfig() {
   if(haveSlopeLimiter) {
     idfx::cout << "Braginskii Thermal Diffusion: uses a slope limiter." << std::endl;
   }
+  if(includeCollisionlessTD) {
+     idfx::cout << "Saturation with collisionless flux is enabled." << std::endl;
+  }
 }
 
 void BragThermalDiffusion::EnrollBragThermalDiffusivity(TwoArrayDiffusivityFunc myFunc) {
   if(this->status.status != UserDefFunction) {
     IDEFIX_WARNING("Braginskii thermal diffusivity enrollment requires Hydro/BragThermalDiffusion "
-                 "to be set to userdef in .ini file");
+                   "to be set to userdef in .ini file");
   }
   this->bragDiffusivityFunc = myFunc;
 }
@@ -63,7 +60,7 @@ void BragThermalDiffusion::EnrollBragThermalDiffusivity(TwoArrayDiffusivityFunc 
 void BragThermalDiffusion::EnrollClessThermalDiffusivity(FourArrayDiffusivityFunc myFunc) {
   if(this->status.status != UserDefFunction) {
     IDEFIX_WARNING("Collisionless/Braginskii thermal diffusivity enrollment requires "
-           "Hydro/BragThermalDiffusion to be set to collisionless in .ini file");
+           "Hydro/BragThermalDiffusion to be set to userdef in .ini file");
   }
   this->clessDiffusivityFunc = myFunc;
 }

--- a/src/fluid/braginskii/bragThermalDiffusion.hpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.hpp
@@ -791,7 +791,7 @@ void BragThermalDiffusion::AddBragDiffusiveFluxLim(int dir, const real t,
 
       bgradT = D_EXPAND( Bi*dTi , + Bj*dTj, +Bk*dTk);
       Bmag = D_EXPAND( Bi*Bi , + Bj*Bj, + Bk*Bk);
-      // EXPAND can yield uexpected behaviour when DIMENSIONS < COMPONENTS
+      // EXPAND can yield unexpected behaviour when DIMENSIONS < COMPONENTS
       //printf("%f , %f\n", Bmag, EXPAND(Bi*Bi, + Bj*Bj, + Bk*Bk));
       Bmag = sqrt(Bmag);
       Bmag = FMAX(1e-6*SMALL_NUMBER,Bmag);

--- a/src/fluid/braginskii/bragThermalDiffusion.hpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.hpp
@@ -260,6 +260,8 @@ void BragThermalDiffusion::AddBragDiffusiveFluxLim(int dir, const real t,
   real kparConstant = this->kpar;
   IdefixArray3D<real> knorArr = this->knorArr;
   IdefixArray3D<real> kparArr = this->kparArr;
+  IdefixArray3D<real> alpha   = this->alpha;
+  IdefixArray3D<real> clessQ  = this->clessQ;
 
   if(haveThermalDiffusion == UserDefFunction && dir == IDIR) {
     if(diffusivityFunc) {

--- a/src/fluid/braginskii/bragThermalDiffusion.hpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.hpp
@@ -59,7 +59,7 @@ class BragThermalDiffusion {
   bool includeCollisionlessTD{false};
 
   bool haveSlopeLimiter{false};
-  bool haveMonotizedCentral{false};
+  bool haveMonotonizedCentral{false};
   bool haveVanLeer{false};
   bool haveMinmod{false};
 
@@ -94,7 +94,7 @@ BragThermalDiffusion::BragThermalDiffusion(Input &input, Grid &grid, Fluid<Phys>
   if(input.CheckEntry("Hydro","bragTDiffusion")>=0) {
     if(input.Get<std::string>("Hydro","bragTDiffusion",1).compare("mc") == 0) {
       this->haveSlopeLimiter = true;
-      this->haveMonotizedCentral = true;
+      this->haveMonotonizedCentral = true;
       limiter = PLMLimiter::McLim;
     } else if(input.Get<std::string>("Hydro","bragTDiffusion",1).compare("vanleer") == 0) {
       this->haveSlopeLimiter = true;

--- a/src/fluid/braginskii/bragThermalDiffusion.hpp
+++ b/src/fluid/braginskii/bragThermalDiffusion.hpp
@@ -133,7 +133,7 @@ BragThermalDiffusion::BragThermalDiffusion(Input &input, Grid &grid, Fluid<Phys>
                      data->np_tot[IDIR]);
     } else {
       IDEFIX_ERROR("Unknown braginskii thermal diffusion definition in idefix.ini. "
-                   "Can only be constant or userdef.");
+                   "Can only be constant, userdef or collisionless.");
     }
   } else {
     IDEFIX_ERROR("I cannot create a BragThermalDiffusion object without bragTDiffusion defined"
@@ -728,13 +728,13 @@ void BragThermalDiffusion::AddBragDiffusiveFluxLim(int dir, const real t,
       bn = Bn/Bmag; /* -- unit vector component -- */
       q = kpar*bgradT*bn + knor*(dTn - bn*bgradT);
       if(includeCollisionlessTD) {
-    q = clessAlpha(k,j,i)*q + (1-clessAlpha(k,j,i))*clessBeta(k,j,i)*Pn*Vn;
+        q = clessAlpha(k,j,i)*q + (1-clessAlpha(k,j,i))*clessBeta(k,j,i)*Pn*Vn;
       }
       Flux(ENG, k, j, i) -= q;
       dMax(k,j,i) = FMAX(dMax(k,j,i),locdmax);
 
       if(includeCollisionlessTD) {
-    dMax(k,j,i) *= clessAlpha(k,j,i);
+        dMax(k,j,i) *= clessAlpha(k,j,i);
       }
     });
   idfx::popRegion();

--- a/src/fluid/braginskii/bragViscosity.cpp
+++ b/src/fluid/braginskii/bragViscosity.cpp
@@ -60,12 +60,11 @@ void BragViscosity::ShowConfig() {
   }
   if(haveSlopeLimiter) {
     if(haveMonotizedCentral) {
-      idfx::cout << "Braginskii Viscosity: uses the monotonized central slope limiter." << std::endl;
-    }
-    else if(haveVanLeer) {
+      idfx::cout << "Braginskii Viscosity: uses the "
+      "monotonized central slope limiter." << std::endl;
+    } else if(haveVanLeer) {
       idfx::cout << "Braginskii Viscosity: uses the van Leer slope limiter." << std::endl;
-    }
-    else {
+    } else {
       IDEFIX_ERROR("Unknown slope limiter for braginskii viscosity.");
     }
   }

--- a/src/fluid/fluid_defs.hpp
+++ b/src/fluid/fluid_defs.hpp
@@ -25,7 +25,7 @@ class Fluid;
 
 
 // Parabolic terms can have different status
-enum HydroModuleStatus {Disabled, Constant, UserDefFunction };
+enum HydroModuleStatus {Disabled, Constant, UserDefFunction, CollisionLess};
 
 // Structure to describe the status of parabolic modules
 struct ParabolicModuleStatus {
@@ -49,12 +49,12 @@ using SrcTermFunc = void (*) (Fluid<Phys> *, const real t, const real dt);
 
 using EmfBoundaryFunc = void (*) (DataBlock &, const real t);
 using DiffusivityFunc = void (*) (DataBlock &, const real t, IdefixArray3D<real> &);
-using BragDiffusivityFunc = void (*) (DataBlock &, const real t,
-                                      IdefixArray3D<real> &, IdefixArray3D<real> &);
+using TwoArrayDiffusivityFunc = void (*) (DataBlock &, const real t,
+                      IdefixArray3D<real> &, IdefixArray3D<real> &);
 
 using FourArrayDiffusivityFunc = void (*) (DataBlock &, const real t,
-                                      IdefixArray3D<real> &, IdefixArray3D<real> &,
-                                      IdefixArray3D<real> &, IdefixArray3D<real> &);
+                       IdefixArray3D<real> &, IdefixArray3D<real> &,
+                       IdefixArray3D<real> &, IdefixArray3D<real> &);
 
 // Deprecated signatures
 using SrcTermFuncOld = void (*) (DataBlock &, const real t, const real dt);

--- a/src/fluid/fluid_defs.hpp
+++ b/src/fluid/fluid_defs.hpp
@@ -25,7 +25,7 @@ class Fluid;
 
 
 // Parabolic terms can have different status
-enum HydroModuleStatus {Disabled, Constant, UserDefFunction, CollisionLess};
+enum HydroModuleStatus {Disabled, Constant, UserDefFunction};
 
 // Structure to describe the status of parabolic modules
 struct ParabolicModuleStatus {

--- a/src/fluid/fluid_defs.hpp
+++ b/src/fluid/fluid_defs.hpp
@@ -8,6 +8,7 @@
 #ifndef FLUID_FLUID_DEFS_HPP_
 #define FLUID_FLUID_DEFS_HPP_
 
+#include <vector>
 #include "../idefix.hpp"
 
 
@@ -49,12 +50,9 @@ using SrcTermFunc = void (*) (Fluid<Phys> *, const real t, const real dt);
 
 using EmfBoundaryFunc = void (*) (DataBlock &, const real t);
 using DiffusivityFunc = void (*) (DataBlock &, const real t, IdefixArray3D<real> &);
-using TwoArrayDiffusivityFunc = void (*) (DataBlock &, const real t,
-                      IdefixArray3D<real> &, IdefixArray3D<real> &);
 
-using FourArrayDiffusivityFunc = void (*) (DataBlock &, const real t,
-                       IdefixArray3D<real> &, IdefixArray3D<real> &,
-                       IdefixArray3D<real> &, IdefixArray3D<real> &);
+using BragDiffusivityFunc = void (*) (DataBlock &, const real,
+                      std::vector<IdefixArray3D<real>> &);
 
 // Deprecated signatures
 using SrcTermFuncOld = void (*) (DataBlock &, const real t, const real dt);

--- a/src/fluid/fluid_defs.hpp
+++ b/src/fluid/fluid_defs.hpp
@@ -52,6 +52,10 @@ using DiffusivityFunc = void (*) (DataBlock &, const real t, IdefixArray3D<real>
 using BragDiffusivityFunc = void (*) (DataBlock &, const real t,
                                       IdefixArray3D<real> &, IdefixArray3D<real> &);
 
+using FourArrayDiffusivityFunc = void (*) (DataBlock &, const real t,
+                                      IdefixArray3D<real> &, IdefixArray3D<real> &,
+                                      IdefixArray3D<real> &, IdefixArray3D<real> &);
+
 // Deprecated signatures
 using SrcTermFuncOld = void (*) (DataBlock &, const real t, const real dt);
 

--- a/test/MHD/MTI/idefix-rkl.ini
+++ b/test/MHD/MTI/idefix-rkl.ini
@@ -12,7 +12,7 @@ nstages        3
 [Hydro]
 solver            hlld
 gamma             1.6666666666666666
-bragTDiffusion    rkl                 nolimiter  userdef
+bragTDiffusion    rkl                 nolimiter  nosat    userdef
 bragViscosity     rkl                 nolimiter  userdef
 
 [Gravity]

--- a/test/MHD/MTI/idefix-sl.ini
+++ b/test/MHD/MTI/idefix-sl.ini
@@ -12,7 +12,7 @@ nstages        3
 [Hydro]
 solver            hlld
 gamma             1.6666666666666666
-bragTDiffusion    rkl                 mc       userdef
+bragTDiffusion    rkl                 mc       nosat    userdef
 bragViscosity     rkl                 vanleer  userdef
 
 [Gravity]

--- a/test/MHD/MTI/idefix.ini
+++ b/test/MHD/MTI/idefix.ini
@@ -12,7 +12,7 @@ nstages        3
 [Hydro]
 solver            hlld
 gamma             1.6666666666666666
-bragTDiffusion    explicit            nolimiter  userdef
+bragTDiffusion    explicit            nolimiter  nosat    userdef
 bragViscosity     explicit            nolimiter  userdef
 
 [Gravity]

--- a/test/MHD/MTI/setup.cpp
+++ b/test/MHD/MTI/setup.cpp
@@ -39,9 +39,13 @@ void Potential(DataBlock& data, const real t, IdefixArray1D<real>& x1, IdefixArr
 }
 
 
-void MyBragThermalConductivity(DataBlock &data, const real t, IdefixArray3D<real> &kparArr, IdefixArray3D<real> &knorArr) {
+void MyBragThermalConductivity(DataBlock &data, const real t, std::vector<IdefixArray3D<real>> &userdefArr) {
   IdefixArray4D<real> Vc = data.hydro->Vc;
   IdefixArray1D<real> x2 = data.x[JDIR];
+
+  IdefixArray3D<real> kparArr = userdefArr[0];
+  IdefixArray3D<real> knorArr = userdefArr[1];
+
   real ksi = ksiGlob;
   idefix_for("MyThConductivity",0,data.np_tot[KDIR],0,data.np_tot[JDIR],0,data.np_tot[IDIR],
               KOKKOS_LAMBDA (int k, int j, int i) {

--- a/test/MHD/MTI/setup.cpp
+++ b/test/MHD/MTI/setup.cpp
@@ -43,8 +43,8 @@ void MyBragThermalConductivity(DataBlock &data, const real t, std::vector<Idefix
   IdefixArray4D<real> Vc = data.hydro->Vc;
   IdefixArray1D<real> x2 = data.x[JDIR];
 
-  IdefixArray3D<real> kparArr = userdefArr[0];
-  IdefixArray3D<real> knorArr = userdefArr[1];
+  IdefixArray3D<real> kparArr = userdefArr.at(0);
+  IdefixArray3D<real> knorArr = userdefArr.at(1);
 
   real ksi = ksiGlob;
   idefix_for("MyThConductivity",0,data.np_tot[KDIR],0,data.np_tot[JDIR],0,data.np_tot[IDIR],

--- a/test/MHD/clessTDiffusion/CMakeLists.txt
+++ b/test/MHD/clessTDiffusion/CMakeLists.txt
@@ -1,0 +1,2 @@
+enable_idefix_property(Idefix_MHD)
+set_idefix_property(Idefix_RECONSTRUCTION Parabolic)

--- a/test/MHD/clessTDiffusion/CMakeLists.txt
+++ b/test/MHD/clessTDiffusion/CMakeLists.txt
@@ -1,2 +1,1 @@
 enable_idefix_property(Idefix_MHD)
-set_idefix_property(Idefix_RECONSTRUCTION Parabolic)

--- a/test/MHD/clessTDiffusion/definitions.hpp
+++ b/test/MHD/clessTDiffusion/definitions.hpp
@@ -1,0 +1,5 @@
+#define     COMPONENTS      3
+#define     DIMENSIONS      1
+#define     GEOMETRY        SPHERICAL
+
+#define     SMALL_PRESSURE_TEMPERATURE   (0.1)

--- a/test/MHD/clessTDiffusion/idefix.ini
+++ b/test/MHD/clessTDiffusion/idefix.ini
@@ -1,0 +1,41 @@
+[Grid]
+X1-grid    1  1.0     256  l  40.0
+X2-grid    1  1.4708  1    u  1.6708
+X3-grid    1  0.9892  1    u  1.0108
+
+[TimeIntegrator]
+CFL            0.4
+CFL_max_var    1.1      # not used
+tstop          300.0
+first_dt       1.e-6
+nstages        2
+
+[Hydro]
+solver            hlld
+gamma             1.6666666666666
+bragTDiffusion    rkl              mc  wcless  userdef
+
+[Gravity]
+potential    central
+Mcentral     1.0
+
+[Boundary]
+X1-beg    userdef
+X1-end    outflow
+X2-beg    periodic
+X2-end    periodic
+X3-beg    periodic
+X3-end    periodic
+
+[Setup]
+UNIT_DENSITY     1.6726e-16
+UNIT_LENGTH      6.9570e10
+UNIT_VELOCITY    4.3670e7
+cs_vesc          0.26
+va_vesc          0.3
+k0               9e-7
+
+[Output]
+vtk    100.0
+dmp    300.0
+log    10

--- a/test/MHD/clessTDiffusion/python/testidefix.py
+++ b/test/MHD/clessTDiffusion/python/testidefix.py
@@ -22,7 +22,7 @@ def gamma_prime(gamma, beta):
     return (gamma+beta*(gamma-1))/(1+beta*(gamma-1))
 
 success = True
-eps = 1e-2
+eps = 3e-4
 
 gamma_eff = np.gradient(prs, r)/np.gradient(rho, r)*rho/prs
 

--- a/test/MHD/clessTDiffusion/python/testidefix.py
+++ b/test/MHD/clessTDiffusion/python/testidefix.py
@@ -1,0 +1,40 @@
+import os
+import sys
+sys.path.append(os.getenv("IDEFIX_DIR"))
+from pytools.vtk_io import readVTK
+import numpy as np
+import inifix
+
+conf = inifix.load("../idefix.ini")
+gamma = conf["Hydro"]["gamma"]
+kappa = conf["Hydro"]["bragTDiffusion"][-1]
+
+current_VTK = readVTK('../data.0003.vtk', geometry='spherical')
+
+rho = current_VTK.data['RHO'].squeeze()
+prs = current_VTK.data['PRS'].squeeze()
+r   = current_VTK.r
+
+idx1=np.where(r > 20)[0][0]
+idx2=np.where(r > 30)[0][0]
+
+def gamma_prime(gamma, beta):
+    return (gamma+beta*(gamma-1))/(1+beta*(gamma-1))
+
+success = True
+eps = 1e-2
+
+gamma_eff = np.gradient(prs, r)/np.gradient(rho, r)*rho/prs
+
+Error=np.abs(gamma_eff[idx1:idx2]-gamma_prime(gamma, 1.5)).mean()
+if Error > eps:
+    success=False
+
+if success:
+    print("SUCCESS")
+    print("Error: {0}".format(Error))
+    sys.exit(0)
+else:
+    print("Failed")
+    print("Error: {0}".format(Error))
+    sys.exit(1)

--- a/test/MHD/clessTDiffusion/setup.cpp
+++ b/test/MHD/clessTDiffusion/setup.cpp
@@ -1,0 +1,149 @@
+#include "idefix.hpp"
+#include "setup.hpp"
+
+real udenGlob;
+real ulenGlob;
+real uvelGlob;
+real gammaGlob;
+real cs_vescGlob;
+real va_vescGlob;
+real k0_Glob;
+real ParkerWind(real);
+
+void MyClessThermalConductivity(DataBlock &data, const real t, IdefixArray3D<real> &kparArr, IdefixArray3D<real> &knorArr, IdefixArray3D<real> &alpha, IdefixArray3D<real> &clessQ) {
+  IdefixArray4D<real> Vc = data.hydro->Vc;
+  IdefixArray1D<real> x1 = data.x[IDIR];
+  IdefixArray1D<real> x2 = data.x[JDIR];
+  real norm = 1.6726e-24*0.5/(udenGlob*uvelGlob*ulenGlob*1.3807e-16);
+  real uTemp=0.5*uvelGlob*uvelGlob*1.6726e-24/1.3807e-16;
+  real k0 = k0_Glob*norm;
+  idefix_for("MyThConductivity",0,data.np_tot[KDIR],0,data.np_tot[JDIR],0,data.np_tot[IDIR],
+         KOKKOS_LAMBDA (int k, int j, int i) {
+           kparArr(k,j,i) = k0*pow(Vc(PRS,k,j,i)/Vc(RHO,k,j,i)*uTemp,2.5);
+           knorArr(k,j,i) = 0.;
+           alpha(k,j,i) = (1.0-tanh(x1(i)-10))/2;
+           clessQ(k,j,i) = -1.5;
+         });
+}
+
+// User-defined boundaries
+void UserDefBoundary(Hydro *hydro, int dir, BoundarySide side, real t) {
+
+  DataBlock *data = hydro->data;
+
+  if( (dir==IDIR) && (side == left)) {
+    IdefixArray4D<real> Vc = hydro->Vc;
+    IdefixArray4D<real> Vs = hydro->Vs;
+    IdefixArray1D<real> x1 = data->x[IDIR];
+
+    real rc,vc,vwind0;
+    real cs=cs_vescGlob*sqrt(2.);
+    real va_vesc = va_vescGlob;
+    real PonRho;
+
+    PonRho = cs*cs;
+    rc = 0.25 / (cs_vescGlob*cs_vescGlob);
+    vc = cs;
+    vwind0 = ParkerWind(1./rc) * cs;
+
+    hydro->boundary->BoundaryFor("UserDefBoundary", dir, side,
+                 KOKKOS_LAMBDA (int k, int j, int i) {
+                   real r = x1(i);
+                   real mu = va_vesc * sqrt(2.);
+                   Vc(RHO,k,j,i) = vwind0/(vwind0 * r * r);
+                   Vc(PRS,k,j,i) = PonRho * Vc(RHO, k, j, i);
+                   Vc(VX1,k,j,i) = vwind0;
+                   Vc(VX2,k,j,i) = 0.0;
+                   Vc(VX3,k,j,i) = 0.0;
+                   Vc(BX1,k,j,i) = mu / (r*r);
+                   Vc(BX2,k,j,i) = 0.0;
+                   Vc(BX3,k,j,i) = 0.0;
+
+                 });
+  }
+}
+
+// Initialisation routine. Can be used to allocate
+// Arrays or variables which are used later on
+Setup::Setup(Input &input, Grid &grid, DataBlock &data, Output &output) {
+  // Set the function for userdefboundary
+  data.hydro->EnrollUserDefBoundary(&UserDefBoundary);
+  data.hydro->bragThermalDiffusion->EnrollClessThermalDiffusivity(&MyClessThermalConductivity);
+  gammaGlob=input.Get<real>("Hydro", "gamma", 0);
+  udenGlob=input.Get<real>("Setup", "UNIT_DENSITY",0);
+  ulenGlob=input.Get<real>("Setup", "UNIT_LENGTH",0);
+  uvelGlob=input.Get<real>("Setup", "UNIT_VELOCITY",0);
+  cs_vescGlob=input.Get<real>("Setup", "cs_vesc", 0);
+  va_vescGlob=input.Get<real>("Setup", "va_vesc", 0);
+  k0_Glob = input.Get<real>("Setup", "k0", 0);
+}
+
+// This routine initialize the flow
+// Note that data is on the device.
+// One can therefore define locally
+// a datahost and sync it, if needed
+void Setup::InitFlow(DataBlock &data) {
+  // Create a host copy
+  DataBlockHost d(data);
+
+  real r,th,rl;
+  real PonRho, vwind0, rc, vc;
+  real cs=cs_vescGlob*sqrt(2.);
+
+
+  rc = 0.25 / (cs_vescGlob*cs_vescGlob);
+  vwind0 = ParkerWind(1./rc) * cs;
+  PonRho = cs*cs;
+  real mu = va_vescGlob * sqrt(2.);
+
+  for(int k = 0; k < d.np_tot[KDIR] ; k++) {
+    for(int j = 0; j < d.np_tot[JDIR] ; j++) {
+      for(int i = 0; i < d.np_tot[IDIR] ; i++) {
+        r=d.x[IDIR](i);
+        th=d.x[JDIR](j);
+        real vwind;
+
+        vwind = ParkerWind(r/rc) * cs;
+
+        d.Vc(RHO,k,j,i) = 1.0*vwind0/(vwind * r * r);
+        d.Vc(PRS,k,j,i) = PonRho * d.Vc(RHO, k, j, i);
+        d.Vc(VX1,k,j,i) = vwind;
+        d.Vc(VX2,k,j,i) = 0.0;
+        d.Vc(VX3,k,j,i) = 0.0;
+
+        rl=d.xl[IDIR](i); // Radius on the left side of the cell
+        d.Vs(BX1s, k, j, i) = mu / (rl*rl);
+
+      }
+    }
+  }
+  // Send it all, if needed
+  d.SyncToDevice();
+}
+
+// Analyse data to produce an output
+void MakeAnalysis(DataBlock & data) {
+}
+
+/**************************************************/
+real ParkerWind(real x)
+/*  Parker wind velocity in unit of iso sound speed
+    x = radius / critical radius.
+**************************************************/
+{
+  real v, f;
+  real vref;
+
+  v = 1e-7;
+  f = v*v-2*log(v)-4/x-4*log(x)+3;
+  if (x>1) {v=10;}
+  while (fabs(f) > 1e-10){
+    vref = v;
+    v = v - 0.5*f/(v-1/v);
+    while (v < 0){
+      v = (v + vref)/2;
+    }
+    f = v*v-2*log(v)-4/x-4*log(x)+3;
+  }
+  return v;
+}

--- a/test/MHD/clessTDiffusion/setup.cpp
+++ b/test/MHD/clessTDiffusion/setup.cpp
@@ -18,10 +18,10 @@ void MyClessThermalConductivity(DataBlock &data, const real t, std::vector<Idefi
   IdefixArray1D<real> x1 = data.x[IDIR];
   IdefixArray1D<real> x2 = data.x[JDIR];
 
-  IdefixArray3D<real> kparArr = userdefArr[0];
-  IdefixArray3D<real> knorArr = userdefArr[1];
-  IdefixArray3D<real> clessAlpha = userdefArr[2];
-  IdefixArray3D<real> clessBeta  = userdefArr[3];
+  IdefixArray3D<real> kparArr = userdefArr.at(0);
+  IdefixArray3D<real> knorArr = userdefArr.at(1);
+  IdefixArray3D<real> clessAlpha = userdefArr.at(2);
+  IdefixArray3D<real> clessBeta  = userdefArr.at(3);
 
   real norm = mp*0.5/(udenGlob*uvelGlob*ulenGlob*kB);
   real uTemp=0.5*uvelGlob*uvelGlob*mp/kB;

--- a/test/MHD/clessTDiffusion/testme.py
+++ b/test/MHD/clessTDiffusion/testme.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+"""
+
+@author: glesur
+"""
+import os
+import sys
+sys.path.append(os.getenv("IDEFIX_DIR"))
+
+import pytools.idfx_test as tst
+
+
+def testMe(test):
+  test.configure()
+  test.compile()
+  inifiles=["idefix.ini"]
+
+  # loop on all the ini files for this test
+  name = "dump.0001.dmp"
+  for ini in inifiles:
+    test.run(inputFile=ini)
+    test.standardTest()
+    if test.init:
+      test.makeReference(filename=name)
+    test.nonRegressionTest(filename=name, tolerance=2e-15)
+
+
+test=tst.idfxTest()
+
+if not test.all:
+  if(test.check):
+    test.checkOnly(filename="dump.0001.dmp")
+  else:
+    testMe(test)
+else:
+  test.noplot = True
+  test.vectPot=False
+  test.single=False
+  test.reconstruction=2
+  test.mpi=False
+  testMe(test)

--- a/test/MHD/sphBragTDiffusion/idefix.ini
+++ b/test/MHD/sphBragTDiffusion/idefix.ini
@@ -13,7 +13,7 @@ nstages        3
 [Hydro]
 solver            hlld
 gamma             1.4
-bragTDiffusion    rkl   nolimiter  constant  50.0
+bragTDiffusion    rkl   nolimiter  nosat  constant  50.0
 
 [Setup]
 amplitude    1e-4


### PR DESCRIPTION
This PR adds an option to the `bragTDiffusion` module. A new keyword is set to either `nosat` or `wcless`. With the latter, the heat flux is a combination of the Braginskii heat flux and a collisionless heat flux \propto p v (where p is the thermal fluid pressure and v the bulk velocity). The transition from the Braginskii to the collisionless form is handled through a third parameter alpha (typically an array that depends on the coordinates or the density) while the amplitude of the collisionless heat flux is controlled by a fourth parameter beta, usually constant but can be userdef.

A test and 1D example is given in test/MHD/clessTDiffusion/.
bragTDiffusion tests have been updated to include the new option.