### PR TITLE
add global routines to dump Idefix arrays to disk

### DIFF
--- a/doc/source/programmingguide.rst
+++ b/doc/source/programmingguide.rst
@@ -645,6 +645,27 @@ It may also be useful to implement debug-only safeguards with custom logic that 
 fit `RUNTIME_CHECK_*` macros. This can be achieved by using the compiler directive
 `#ifdef RUNTIME_CHECKS` directly.
 
+Dump an array to a file
+-----------------------
+
+It is usually difficult to know what Idefix arrays effectively contains, especially when running on GPU.
+To help with this difficulty, Idefix provides a global function ``DumpArray`` that can be used
+to dump a ``IdefixArray`` to a numpy file (that can be read from python). This feature can be used
+for debugging purpose as:
+
+
+.. code-block:: c++
+
+  #include "idefix.hpp"
+
+  IdefixArray3D<real> myArray("debugMe",10,10,10);
+
+  idfx::DumpArray("myFilename.npy",myArray); // Dump the array content to a numpy file named "myFilename.npy"
+
+
+Note that the array is automatically transfered from the GPU, if needed.
+
+
 Minimal skeleton
 ================
 

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include "arrays.hpp"
+#include "npy.hpp"
 
 namespace idfx {
 int initialize();   // Initialisation routine for idefix

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -46,31 +46,17 @@ IdefixArray1D<T> ConvertVectorToIdefixArray(std::vector<T> &inputVector) {
 }
 
 ///< dump Idefix array to a numpy array on disk
-template<typename T>
-void dumpArray(std::string filename, IdefixArray3D<T> array) {
-  IdefixHostArray3D<T> hArray = Kokkos::create_mirror(array);
-  Kokkos::deep_copy(hArray,array);
+template<typename ArrayType>
+void DumpArray(std::string filename, ArrayType array) {
+  auto hArray = Kokkos::create_mirror(array);
+  Kokkos::deep_copy(hArray, array);
 
-  std::array<uint64_t,3> shape;
+  std::array<uint64_t, ArrayType::rank> shape;
   bool fortran_order{false};
-  shape[0] = array.extent(0);
-  shape[1] = array.extent(1);
-  shape[2] = array.extent(2);
-  npy::SaveArrayAsNumpy(filename, fortran_order, 3, shape.data(), hArray.data());
-}
-
-template<typename T>
-void dumpArray(std::string filename, IdefixArray4D<T> array) {
-  IdefixHostArray4D<T> hArray = Kokkos::create_mirror(array);
-  Kokkos::deep_copy(hArray,array);
-
-  std::array<uint64_t,4> shape;
-  bool fortran_order{false};
-  shape[0] = array.extent(0);
-  shape[1] = array.extent(1);
-  shape[2] = array.extent(2);
-  shape[3] = array.extent(3);
-  npy::SaveArrayAsNumpy(filename, fortran_order, 4, shape.data(), hArray.data());
+  for (size_t i = 0; i < ArrayType::rank; ++i) {
+    shape[i] = array.extent(i);
+  }
+  npy::SaveArrayAsNumpy(filename, fortran_order, ArrayType::rank, shape.data(), hArray.data());
 }
 
 } // namespace idfx

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -44,6 +44,34 @@ IdefixArray1D<T> ConvertVectorToIdefixArray(std::vector<T> &inputVector) {
   return(outArr);
 }
 
+///< dump Idefix array to a numpy array on disk
+template<typename T>
+void dumpArray(std::string filename, IdefixArray3D<T> array) {
+  IdefixHostArray3D<T> hArray = Kokkos::create_mirror(array);
+  Kokkos::deep_copy(hArray,array);
+
+  std::array<uint64_t,3> shape;
+  bool fortran_order{false};
+  shape[0] = array.extent(0);
+  shape[1] = array.extent(1);
+  shape[2] = array.extent(2);
+  npy::SaveArrayAsNumpy(filename, fortran_order, 3, shape.data(), hArray.data());
+}
+
+template<typename T>
+void dumpArray(std::string filename, IdefixArray4D<T> array) {
+  IdefixHostArray4D<T> hArray = Kokkos::create_mirror(array);
+  Kokkos::deep_copy(hArray,array);
+
+  std::array<uint64_t,4> shape;
+  bool fortran_order{false};
+  shape[0] = array.extent(0);
+  shape[1] = array.extent(1);
+  shape[2] = array.extent(2);
+  shape[3] = array.extent(3);
+  npy::SaveArrayAsNumpy(filename, fortran_order, 4, shape.data(), hArray.data());
+}
+
 } // namespace idfx
 
 class idfx::IdefixOutStream {


### PR DESCRIPTION
add global routines to dump Idefix arrays (useful for debugging or checking that everything works as expected). The file produced is a numpy .npy file, that can be read back with numpy.
