### PR TITLE
Implicit drag for dust species

### DIFF
--- a/src/dataBlock/evolveStage.cpp
+++ b/src/dataBlock/evolveStage.cpp
@@ -19,6 +19,16 @@ void DataBlock::EvolveStage() {
     for(int i = 0 ; i < dust.size() ; i++) {
       dust[i]->EvolveStage(this->t,this->dt);
     }
+    // Add implicit term for dust drag
+    if(dust[0]->drag->IsImplicit()) {
+      for(int i = 0 ; i < dust.size() ; i++) {
+        dust[i]->drag->AddImplicitBackReaction(this->dt,dust[0]->drag->implicitFactor);
+      }
+      dust[0]->drag->NormalizeImplicitBackReaction(this->dt);
+      for(int i = 0 ; i < dust.size() ; i++) {
+        dust[i]->drag->AddImplicitFluidMomentum(this->dt);
+      }
+    }
   }
 
   idfx::popRegion();

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -216,7 +216,7 @@ void GammaDrag::RefreshUserDrag(DataBlock *data) {
   if(type == Type::Userdef) {
     if(userDrag != NULL) {
       idfx::pushRegion("GammaDrag::UserDrag");
-        userDrag(data, dragCoeff, gammai);
+        userDrag(data, instanceNumber, dragCoeff, gammai);
       idfx::popRegion();
     } else {
       IDEFIX_ERROR("No User-defined drag function has been enrolled");
@@ -260,4 +260,5 @@ GammaDrag::GammaDrag(Input &input, std::string BlockName, int instanceNumber, Da
   }
   // Fetch the drag coefficient for the current specie.
   this->dragCoeff = input.Get<real>(BlockName,"drag",instanceNumber+1);
+  this->instanceNumber = instanceNumber;
 }

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -47,6 +47,7 @@ void Drag::AddDragForce(const real dt) {
             UcGas(ENG,k,j,i) += dp*dv*VcDust(n,k,j,i);
           #endif
         } // feedback
+      }
       // Cfl constraint
       real idt = gamma*VcGas(RHO,k,j,i);
       if(feedback) idt += gamma*VcDust(RHO,k,j,i);

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -73,8 +73,6 @@ void Drag::AddImplicitBackReaction(const real dt, IdefixArray3D<real> preFactor)
   auto VcDust = this->VcDust;
   auto UcDust = this->UcDust;
 
-  bool feedback = this->feedback;
-
   bool isFirst = this->instanceNumber == 0;
 
 

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -6,10 +6,7 @@
 // ***********************************************************************************
 #include "drag.hpp"
 #include <string>
-
 #include "physics.hpp"
-
-
 
 void Drag::AddDragForce(const real dt) {
   idfx::pushRegion("Drag::AddDragForce");

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -71,6 +71,7 @@ void Drag::AddImplicitBackReaction(const real dt, IdefixArray3D<real> preFactor)
   auto UcGas = this->UcGas;
   auto VcGas = this->VcGas;
   auto VcDust = this->VcDust;
+  auto UcDust = this->UcDust;
 
   bool feedback = this->feedback;
 

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -89,7 +89,7 @@ void Drag::AddImplicitBackReaction(const real dt, IdefixArray3D<real> preFactor)
       real gamma = gammaDrag.GetGamma(k,j,i);  // The drag coefficient
 
 
-      const real factor = VcDust(RHO,k,j,i)*gamma*dt/(1+VcGas(RHO,k,j,i)*gamma*dt);
+      const real factor = UcDust(RHO,k,j,i)*gamma*dt/(1+UcGas(RHO,k,j,i)*gamma*dt);
       if(isFirst) {
         preFactor(k,j,i) = factor;
       } else {
@@ -97,8 +97,8 @@ void Drag::AddImplicitBackReaction(const real dt, IdefixArray3D<real> preFactor)
       }
 
       for(int n = MX1 ; n < MX1+COMPONENTS ; n++) {
-        UcGas(n,k,j,i) +=  dt * gamma * VcGas(RHO,k,j,i) * UcDust(n,k,j,i) /
-                                                                   (1 + VcGas(RHO,k,j,i)*dt*gamma);
+        UcGas(n,k,j,i) +=  dt * gamma * UcGas(RHO,k,j,i) * UcDust(n,k,j,i) /
+                                                                   (1 + UcGas(RHO,k,j,i)*dt*gamma);
       }
     });
   idfx::popRegion();
@@ -156,8 +156,8 @@ void Drag::AddImplicitFluidMomentum(const real dt) {
 
       for(int n = MX1 ; n < MX1+COMPONENTS ; n++) {
         real oldUc = UcDust(n,k,j,i);
-        UcDust(n,k,j,i) = (oldUc + dt * gamma * VcDust(RHO,k,j,i) * UcGas(n,k,j,i)) /
-                          (1 + VcGas(RHO,k,j,i)*dt*gamma);
+        UcDust(n,k,j,i) = (oldUc + dt * gamma * UcDust(RHO,k,j,i) * UcGas(n,k,j,i)) /
+                          (1 + UcGas(RHO,k,j,i)*dt*gamma);
 
         #if HAVE_ENERGY == 1
           real dp = UcDust(n,k,j,i) - oldUc;
@@ -167,7 +167,7 @@ void Drag::AddImplicitFluidMomentum(const real dt) {
 
           // TODO(GL): this should be disabled in the case of a true multifluid system where
           // both fluids have a proper energy equation
-          UcGas(ENG,k,j,i) -= dp*VcDust(n,k,j,i);
+          UcGas(ENG,k,j,i) -= dp*UcDust(n,k,j,i)/UcDust(RHO,k,j,i);
         #endif
       }
     });

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -36,16 +36,17 @@ void Drag::AddDragForce(const real dt) {
       for(int n = MX1 ; n < MX1+COMPONENTS ; n++) {
         real dv = VcDust(n,k,j,i) - VcGas(n,k,j,i);
         UcDust(n,k,j,i) -= dp*dv;
-        if(feedback) UcGas(n,k,j,i) += dp*dv;
-        #if HAVE_ENERGY == 1
-          // We add back the energy dissipated for the dust which is not accounted for
-          // (since there is no energy equation for dust grains)
+        if(feedback) {
+          UcGas(n,k,j,i) += dp*dv;
+          #if HAVE_ENERGY == 1
+            // We add back the energy dissipated for the dust which is not accounted for
+            // (since there is no energy equation for dust grains)
 
-          // TODO(GL): this should be disabled in the case of a true multifluid system where
-          // both fluids have a proper energy equation
-          UcGas(ENG,k,j,i) += dp*dv*VcDust(n,k,j,i);
-        #endif
-      }
+            // TODO(GL): this should be disabled in the case of a true multifluid system where
+            // both fluids have a proper energy equation
+            UcGas(ENG,k,j,i) += dp*dv*VcDust(n,k,j,i);
+          #endif
+        } // feedback
       // Cfl constraint
       real idt = gamma*VcGas(RHO,k,j,i);
       if(feedback) idt += gamma*VcDust(RHO,k,j,i);
@@ -167,7 +168,7 @@ void Drag::AddImplicitFluidMomentum(const real dt) {
 
           // TODO(GL): this should be disabled in the case of a true multifluid system where
           // both fluids have a proper energy equation
-          UcGas(ENG,k,j,i) -= dp*UcDust(n,k,j,i)/UcDust(RHO,k,j,i);
+          if(feedback) UcGas(ENG,k,j,i) -= dp*UcDust(n,k,j,i)/UcDust(RHO,k,j,i);
         #endif
       }
     });

--- a/src/fluid/drag.cpp
+++ b/src/fluid/drag.cpp
@@ -169,7 +169,7 @@ void Drag::AddImplicitFluidMomentum(const real dt) {
 
           // TODO(GL): this should be disabled in the case of a true multifluid system where
           // both fluids have a proper energy equation
-          if(feedback) UcGas(ENG,k,j,i) -= dp*UcDust(n,k,j,i)/UcDust(RHO,k,j,i);
+          if(feedback) UcGas(ENG,k,j,i) -= dp*VcDust(n,k,j,i);
         #endif
       }
     });

--- a/src/fluid/drag.hpp
+++ b/src/fluid/drag.hpp
@@ -13,7 +13,7 @@
 #include "fluid_defs.hpp"
 #include "eos.hpp"
 
-using UserDefDragFunc = void (*) (DataBlock *, real beta, IdefixArray3D<real> &gammai);
+using UserDefDragFunc = void (*) (DataBlock *, int n, real beta, IdefixArray3D<real> &gammai);
 
 /* A class that holds the kind of drag law we intend to use */
 class GammaDrag {
@@ -55,6 +55,7 @@ class GammaDrag {
   IdefixArray3D<real> gammai;
   IdefixArray4D<real> VcGas;
 
+  int instanceNumber;
   UserDefDragFunc userDrag{NULL};
 };
 
@@ -92,9 +93,6 @@ class Drag {
   bool implicit{false};
   int instanceNumber;
 };
-
-
-
 
 
 #include "fluid.hpp"

--- a/src/fluid/drag.hpp
+++ b/src/fluid/drag.hpp
@@ -15,10 +15,52 @@
 
 using UserDefDragFunc = void (*) (DataBlock *, real beta, IdefixArray3D<real> &gammai);
 
+/* A class that holds the kind of drag law we intend to use */
+class GammaDrag {
+ public:
+  enum class Type{Gamma, Tau, Size, Userdef};
+  GammaDrag() = default;
+  GammaDrag(Input &, std::string BlockName, int instanceNumber, DataBlock *data);
+  void EnrollUserDrag(UserDefDragFunc);
+  void RefreshUserDrag(DataBlock *);
+
+  KOKKOS_INLINE_FUNCTION real GetGamma(const int k, const int j, const int i) const {
+    real gamma;  // The drag coefficient
+    if(type ==  Type::Gamma) {
+      gamma = dragCoeff;
+
+    } else if(type == Type::Tau) {
+      // In this case, the coefficient is the stopping time (assumed constant)
+      gamma = 1/(dragCoeff*VcGas(RHO,k,j,i));
+    } else if(type == Type::Size) {
+      real cs;
+      // Assume a fixed size, hence for both Epstein or Stokes, gamma~1/rho_g/cs
+      // Get the sound speed
+      #if HAVE_ENERGY == 1
+        cs = std::sqrt(eos.GetGamma(VcGas(PRS,k,j,i),VcGas(RHO,k,j,i)
+                        *VcGas(PRS,k,j,i)/VcGas(RHO,k,j,i)));
+      #else
+        cs = eos.GetWaveSpeed(k,j,i);
+      #endif
+      gamma = cs/dragCoeff;
+    } else if(type == Type::Userdef) {
+      gamma = gammai(k,j,i);
+    }
+    return gamma;
+  }
+
+  Type type;
+  real dragCoeff;
+  EquationOfState eos;
+  IdefixArray3D<real> gammai;
+  IdefixArray4D<real> VcGas;
+
+  UserDefDragFunc userDrag{NULL};
+};
+
 
 class Drag {
  public:
-  enum class Type{Gamma, Tau, Size, Userdef};
   // Different types of implementation for the drag force.
   template <typename Phys>
   Drag(Input &, Fluid<Phys> *);
@@ -40,24 +82,20 @@ class Drag {
   IdefixArray4D<real> VcDust;  // Gas primitive quantities
   IdefixArray4D<real> VcGas;  // Gas primitive quantities
   IdefixArray3D<real> InvDt;  // The InvDt of current dust specie
-  IdefixArray3D<real> gammai; // the drag coefficient (only used for user-defined dust grains)
   IdefixArray3D<real> implicitFactor; // The prefactor used by the implicit timestepping
 
-  Type type;
+  GammaDrag gammaDrag;  // The drag law
 
  private:
   DataBlock* data;
-  real dragCoeff;
   bool feedback{false};
   bool implicit{false};
   int instanceNumber;
-
-
-  UserDefDragFunc userDrag{NULL};
-
-  // Sound speed computation
-  EquationOfState *eos;
 };
+
+
+
+
 
 #include "fluid.hpp"
 
@@ -72,47 +110,22 @@ Drag::Drag(Input &input, Fluid<Phys> *hydroin):
   // Save the parent hydro object
 
   this->data = hydroin->data;
-  // We use the EOS of the basic fluid instance, as there is no EOS for dust!
-  this->eos = hydroin->data->hydro->eos.get();
 
   // Check in which block we should fetch our information
-  std::string BlockName;
+  std::string blockName;
   if(Phys::dust) {
-    BlockName = "Dust";
+    blockName = "Dust";
   } else {
     IDEFIX_ERROR("Drag is currently implemented only for dusty fuids");
   }
 
-  if(input.CheckEntry(BlockName,"drag")>=0) {
-    std::string dragType = input.Get<std::string>(BlockName,"drag",0);
-    if(dragType.compare("gamma") == 0) {
-      this->type = Type::Gamma;
-    } else if(dragType.compare("tau") == 0) {
-      this->type = Type::Tau;
-    } else if(dragType.compare("size") == 0) {
-      this->type = Type::Size;
-    } else if(dragType.compare("userdef") == 0) {
-      this->type = Type::Userdef;
-      this->gammai = IdefixArray3D<real>("UserDrag",
-                                  data->np_tot[KDIR],
-                                  data->np_tot[JDIR],
-                                  data->np_tot[IDIR]);
-    } else {
-      std::stringstream msg;
-      msg << "Unknown drag type \"" <<  dragType
-          << "\" in your input file." << std::endl
-          << "Allowed values are: gamma, tau, epstein, stokes, userdef." << std::endl;
-
-      IDEFIX_ERROR(msg);
-    }
-    // Fetch the drag coefficient for the current specie.
+  if(input.CheckEntry(blockName,"drag")>=0) {
     this->instanceNumber = hydroin->instanceNumber;
-    this->dragCoeff = input.Get<real>(BlockName,"drag",instanceNumber+1);
+    this->gammaDrag = GammaDrag(input,blockName,instanceNumber,data);
 
     // Feedback is true by default, but can be switched off.
-    this->feedback = input.GetOrSet<bool>(BlockName,"drag_feedback",0,true);
-
-    this->implicit = input.GetOrSet<bool>(BlockName,"drag_implicit",0,false);
+    this->feedback = input.GetOrSet<bool>(blockName,"drag_feedback",0,true);
+    this->implicit = input.GetOrSet<bool>(blockName,"drag_implicit",0,false);
 
     if(implicit && instanceNumber == 0) {
       this->implicitFactor = IdefixArray3D<real>("ImplicitFactor",

--- a/src/fluid/evolveStage.hpp
+++ b/src/fluid/evolveStage.hpp
@@ -61,7 +61,11 @@ void Fluid<Phys>::EvolveStage(const real t, const real dt) {
   if(haveSourceTerms) AddSourceTerms(t, dt);
 
   // Step 5: add drag when needed
-  if(haveDrag) drag->AddDragForce(dt);
+  if(haveDrag) {
+    if(!drag->IsImplicit()) {
+      drag->AddDragForce(dt);
+    }
+  }
 
   if constexpr(Phys::mhd) {
     #if DIMENSIONS >= 2

--- a/src/fluid/fluid.hpp
+++ b/src/fluid/fluid.hpp
@@ -585,52 +585,55 @@ Fluid<Phys>::Fluid(Grid &grid, Input &input, DataBlock *datain, int n) {
   }
 
   for(int i = 0 ; i < Phys::nvar+nTracer ;  i++) {
-    switch(i) {
-      case RHO:
-        VcName.push_back("RHO");
-        data->dump->RegisterVariable(Vc, outputPrefix+"Vc-RHO", RHO);
-        break;
-      case VX1:
-        VcName.push_back("VX1");
-        data->dump->RegisterVariable(Vc, outputPrefix+"Vc-VX1", VX1, IDIR);
-        break;
-      case VX2:
-        VcName.push_back("VX2");
-        data->dump->RegisterVariable(Vc, outputPrefix+"Vc-VX2", VX2, JDIR);
-        break;
-      case VX3:
-        VcName.push_back("VX3");
-        data->dump->RegisterVariable(Vc, outputPrefix+"Vc-VX3", VX3, KDIR);
-        break;
-      case BX1:
-        VcName.push_back("BX1");
-        // never save cell-centered BX1 in dumps
-        break;
-      case BX2:
-        VcName.push_back("BX2");
-        #if DIMENSIONS < 2
-          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-BX2", BX2, JDIR);
-        #endif
-        break;
-      case BX3:
-        VcName.push_back("BX3");
-        #if DIMENSIONS < 3
-          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-BX3", BX3, KDIR);
-        #endif
-        break;
-      case PRS:
-        VcName.push_back("PRS");
-        data->dump->RegisterVariable(Vc, outputPrefix+"Vc-PRS", PRS);
-        break;
-      default:
-        if(i>=Phys::nvar) {
-          std::string tracerLabel = std::string("TR")+std::to_string(i-Phys::nvar); // ="TRn"
-          VcName.push_back(tracerLabel);
-          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-"+tracerLabel, i);
-        } else {
+    if(i < Phys::nvar) {
+      // These are standard variable names
+      switch(i) {
+        case RHO:
+          VcName.push_back("RHO");
+          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-RHO", RHO);
+          break;
+        case VX1:
+          VcName.push_back("VX1");
+          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-VX1", VX1, IDIR);
+          break;
+        case VX2:
+          VcName.push_back("VX2");
+          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-VX2", VX2, JDIR);
+          break;
+        case VX3:
+          VcName.push_back("VX3");
+          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-VX3", VX3, KDIR);
+          break;
+        case BX1:
+          VcName.push_back("BX1");
+          // never save cell-centered BX1 in dumps
+          break;
+        case BX2:
+          VcName.push_back("BX2");
+          #if DIMENSIONS < 2
+            data->dump->RegisterVariable(Vc, outputPrefix+"Vc-BX2", BX2, JDIR);
+          #endif
+          break;
+        case BX3:
+          VcName.push_back("BX3");
+          #if DIMENSIONS < 3
+            data->dump->RegisterVariable(Vc, outputPrefix+"Vc-BX3", BX3, KDIR);
+          #endif
+          break;
+        case PRS:
+          VcName.push_back("PRS");
+          data->dump->RegisterVariable(Vc, outputPrefix+"Vc-PRS", PRS);
+          break;
+        default:
+          // unknown variable name (this should never happen, but who knows...)
           VcName.push_back("Vc-"+std::to_string(i));
           data->vtk->RegisterVariable(Vc, outputPrefix+"Vc-"+std::to_string(i), i);
-        }
+          break;
+      }
+    } else { //if(i>=Phys::nvar)
+      std::string tracerLabel = std::string("TR")+std::to_string(i-Phys::nvar); // ="TRn"
+      VcName.push_back(tracerLabel);
+      data->dump->RegisterVariable(Vc, outputPrefix+"Vc-"+tracerLabel, i);
     }
     data->vtk->RegisterVariable(Vc, outputPrefix+VcName[i], i);
     #ifdef WITH_HDF5

--- a/test/Dust/DustEnergy/idefix-implicit.ini
+++ b/test/Dust/DustEnergy/idefix-implicit.ini
@@ -1,0 +1,36 @@
+# This test checks that the total energy (thermal+dust kinetic+gas kinetic)
+# is effectively conserved when drag is present
+
+[Grid]
+X1-grid    1  0.0  500  u  1.0
+X2-grid    1  0.0  1    u  1.0
+X3-grid    1  0.0  1    u  1.0
+
+[TimeIntegrator]
+CFL         0.8
+tstop       1.0
+first_dt    1.e-4
+nstages     2
+
+[Hydro]
+solver    hllc
+gamma     1.4
+
+[Dust]
+nSpecies         1
+drag             tau  1.0
+drag_feedback    yes
+drag_implicit    yes
+
+[Boundary]
+X1-beg    periodic
+X1-end    periodic
+X2-beg    outflow
+X2-end    outflow
+X3-beg    outflow
+X3-end    outflow
+
+[Output]
+dmp         1.0
+analysis    0.01
+log         1000

--- a/test/Dust/DustEnergy/testme.py
+++ b/test/Dust/DustEnergy/testme.py
@@ -15,7 +15,7 @@ name="dump.0001.dmp"
 def testMe(test):
   test.configure()
   test.compile()
-  inifiles=["idefix.ini"]
+  inifiles=["idefix.ini","idefix-implicit.ini"]
 
   # loop on all the ini files for this test
   for ini in inifiles:

--- a/test/Dust/DustyShock/definitions.hpp
+++ b/test/Dust/DustyShock/definitions.hpp
@@ -1,0 +1,5 @@
+#define     COMPONENTS      1
+#define     DIMENSIONS      1
+#define     ISOTHERMAL
+
+#define     GEOMETRY        CARTESIAN

--- a/test/Dust/DustyShock/idefix-implicit.ini
+++ b/test/Dust/DustyShock/idefix-implicit.ini
@@ -1,0 +1,36 @@
+# This test checks the behaviour of a dust sound shock
+# following the 4 fluids test of Benitez-Llambay+ 2019
+
+[Grid]
+X1-grid    1  0.0  400  u  40.0
+X2-grid    1  0.0  1    u  1.0
+X3-grid    1  0.0  1    u  1.0
+
+[TimeIntegrator]
+CFL         0.8
+tstop       500.0
+first_dt    1.e-4
+nstages     2
+
+[Hydro]
+solver    hllc
+csiso     constant  1.0
+
+[Dust]
+nSpecies         3
+drag             userdef  1.0  3.0  5.0
+drag_feedback    yes
+drag_implicit    yes
+
+[Boundary]
+X1-beg    userdef
+X1-end    userdef
+X2-beg    outflow
+X2-end    outflow
+X3-beg    outflow
+X3-end    outflow
+
+[Output]
+# dmp         10.0
+vtk    500.0
+log    1000

--- a/test/Dust/DustyShock/idefix-implicit.ini
+++ b/test/Dust/DustyShock/idefix-implicit.ini
@@ -31,6 +31,6 @@ X3-beg    outflow
 X3-end    outflow
 
 [Output]
-# dmp         10.0
+dmp    500.0
 vtk    500.0
 log    1000

--- a/test/Dust/DustyShock/idefix.ini
+++ b/test/Dust/DustyShock/idefix.ini
@@ -1,0 +1,35 @@
+# This test checks the behaviour of a dust sound shock
+# following the 4 fluids test of Benitez-Llambay+ 2019
+
+[Grid]
+X1-grid    1  0.0  400  u  40.0
+X2-grid    1  0.0  1    u  1.0
+X3-grid    1  0.0  1    u  1.0
+
+[TimeIntegrator]
+CFL         0.8
+tstop       500.0
+first_dt    1.e-4
+nstages     2
+
+[Hydro]
+solver    hllc
+csiso     constant  1.0
+
+[Dust]
+nSpecies         3
+drag             userdef  1.0  3.0  5.0
+drag_feedback    yes
+
+[Boundary]
+X1-beg    userdef
+X1-end    userdef
+X2-beg    outflow
+X2-end    outflow
+X3-beg    outflow
+X3-end    outflow
+
+[Output]
+# dmp         10.0
+vtk    500.0
+log    1000

--- a/test/Dust/DustyShock/idefix.ini
+++ b/test/Dust/DustyShock/idefix.ini
@@ -30,6 +30,6 @@ X3-beg    outflow
 X3-end    outflow
 
 [Output]
-# dmp         10.0
+dmp    500.0
 vtk    500.0
 log    1000

--- a/test/Dust/DustyShock/python/testidefix.py
+++ b/test/Dust/DustyShock/python/testidefix.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar  5 11:29:41 2020
+
+@author: glesur
+"""
+
+import os
+import sys
+sys.path.append(os.getenv("IDEFIX_DIR"))
+from pytools.vtk_io import readVTK
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.integrate import solve_ivp
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-noplot",
+                    default=False,
+                    help="disable plotting",
+                    action="store_true")
+
+
+args, unknown=parser.parse_known_args()
+
+V=readVTK('../data.0001.vtk', geometry='cartesian')
+
+# Find where the shock starts
+istart = np.argwhere(V.data['RHO'][:,0,0]>2.0)[0][0]-1
+
+# Compute analytical solution
+M=2 # Mach number
+K=np.asarray([1,3,5])/M # Drag coefficients
+
+# (56) from Benitez-Llambay 2018
+def get_wg(Mach, wi):
+    coeff=[1,np.sum(wi-1)-1/Mach**2-1,1/Mach**2]
+    solution=np.roots(coeff)
+    return(np.min(solution))
+
+# (55) from Benitez-Llambay 2018
+def rhs(t,wi,Mach,K):
+    wg = get_wg(Mach,wi)
+    return K*(wg-wi)
+
+wi0=np.asarray([1.0,1.0,1.0])
+x=V.x[istart:]
+arguments=M,K
+
+sol = solve_ivp(rhs, t_span=[x[0],x[-1]], y0=wi0, t_eval=x,args=arguments)
+
+# compute gas velocity
+wg=np.zeros(len(x))
+for i in range(0,len(wg)):
+    wg[i]=get_wg(M,sol.y[:,i])
+
+
+if(not args.noplot):
+    plt.figure(1)
+    plt.plot(V.x,V.data['RHO'][:,0,0],'o',markersize=4,color='tab:purple')
+    plt.plot(x,1/wg,color='tab:purple')
+    plt.plot(V.x,V.data['Dust0_RHO'][:,0,0],'o',markersize=4,color='tab:orange')
+    plt.plot(x,1/sol.y[0,:],color='tab:orange')
+    plt.plot(V.x,V.data['Dust1_RHO'][:,0,0],'o',markersize=4,color='tab:blue')
+    plt.plot(x,1/sol.y[1,:],color='tab:blue')
+    plt.plot(V.x,V.data['Dust2_RHO'][:,0,0],'o',markersize=4,color='tab:green')
+    plt.plot(x,1/sol.y[2,:],color='tab:green')
+    plt.xlim([0,10])
+    plt.title('Density')
+
+    plt.figure(2)
+    plt.plot(V.x,V.data['VX1'][:,0,0],'o',markersize=4,color='tab:purple')
+    plt.plot(x,M*wg,color='tab:purple')
+    plt.plot(V.x[::4],V.data['Dust0_VX1'][::4,0,0],'o',markersize=4,color='tab:orange')
+    plt.plot(x,M*sol.y[0,:],color='tab:orange')
+    plt.plot(V.x[::4],V.data['Dust1_VX1'][::4,0,0],'o',markersize=4,color='tab:blue')
+    plt.plot(x,M*sol.y[1,:],color='tab:blue')
+    plt.plot(V.x[::4],V.data['Dust2_VX1'][::4,0,0],'o',markersize=4,color='tab:green')
+    plt.plot(x,M*sol.y[2,:],color='tab:green')
+
+    plt.xlim([0,10])
+    plt.title('Velocity')
+
+    plt.ioff()
+    plt.show()
+
+# Compute the error on the dust densities
+
+error=np.mean(np.fabs(V.data['Dust0_RHO'][istart:,0,0]-1/sol.y[0,:]) + np.fabs(V.data['Dust1_RHO'][istart:,0,0]-1/sol.y[1,:]) + np.fabs(V.data['Dust2_RHO'][istart:,0,0]-1/sol.y[2,:])) / 3
+print("Error=%e"%error)
+if error<3.6e-2:
+    print("SUCCESS!")
+    sys.exit(0)
+else:
+    print("FAILURE!")
+    sys.exit(1)

--- a/test/Dust/DustyShock/setup.cpp
+++ b/test/Dust/DustyShock/setup.cpp
@@ -1,0 +1,99 @@
+#include "idefix.hpp"
+#include "setup.hpp"
+
+#define  FILENAME    "timevol.dat"
+
+void MyDrag(DataBlock *data, int n, real beta, IdefixArray3D<real> &gamma) {
+  // Compute the drag coefficient gamma from the input beta
+  auto VcGas = data->hydro->Vc;
+  auto VcDust = data->dust[n]->Vc;
+
+  idefix_for("MyDrag",0,data->np_tot[KDIR],0,data->np_tot[JDIR],0,data->np_tot[IDIR],
+    KOKKOS_LAMBDA (int k, int j, int i) {
+      gamma(k,j,i) = beta/VcGas(RHO,k,j,i)/VcDust(RHO,k,j,i);
+    });
+}
+
+
+void ApplyBoundary(DataBlock *data, IdefixArray4D<real> Vc, int dir, BoundarySide side) {
+  if(dir==IDIR) {
+    int iref,ibeg,iend;
+    if(side == left) {
+      iref = data->beg[IDIR];
+      ibeg = 0;
+      iend = data->beg[IDIR];
+    } else {
+      iref =data->end[IDIR] - 1;
+      ibeg=data->end[IDIR];
+      iend=data->np_tot[IDIR];
+    }
+    int nvar = Vc.extent(0);
+    idefix_for("UserDefBoundary",0,data->np_tot[KDIR],0,data->np_tot[JDIR],ibeg,iend,
+      KOKKOS_LAMBDA (int k, int j, int i) {
+        for(int n = 0 ; n < nvar ; n++) {
+          Vc(n,k,j,i) = Vc(n,k,j,iref );
+        }
+    });
+  }
+}
+
+void UserdefBoundary(Hydro *hydro, int dir, BoundarySide side, real t) {
+  ApplyBoundary(hydro->data, hydro->Vc, dir, side);
+}
+
+void UserdefBoundaryDust(Fluid<DustPhysics> *dust, int dir, BoundarySide side, real t) {
+  ApplyBoundary(dust->data, dust->Vc, dir, side);
+}
+
+
+// Initialisation routine. Can be used to allocate
+// Arrays or variables which are used later on
+Setup::Setup(Input &input, Grid &grid, DataBlock &data, Output &output) {
+
+  data.hydro->EnrollUserDefBoundary(&UserdefBoundary);
+  if(data.haveDust) {
+    int nSpecies = data.dust.size();
+    for(int n = 0 ; n < nSpecies ; n++) {
+      data.dust[n]->EnrollUserDefBoundary(&UserdefBoundaryDust);
+      data.dust[n]->drag->EnrollUserDrag(&MyDrag);
+    }
+  }
+
+}
+
+// This routine initialize the flow
+// Note that data is on the device.
+// One can therefore define locally
+// a datahost and sync it, if needed
+void Setup::InitFlow(DataBlock &data) {
+    // Create a host copy
+    DataBlockHost d(data);
+
+    const real x0 = 4.0;
+
+    for(int k = 0; k < d.np_tot[KDIR] ; k++) {
+        for(int j = 0; j < d.np_tot[JDIR] ; j++) {
+            for(int i = 0; i < d.np_tot[IDIR] ; i++) {
+                real x = d.x[IDIR](i);
+
+                d.Vc(RHO,k,j,i) =  (x < x0) ? 1.0 : 16.0;
+                d.Vc(VX1,k,j,i) = (x < x0) ? 2.0 : 0.125;
+
+                for(int n = 0 ; n < data.dust.size(); n++) {
+                  d.dustVc[n](RHO,k,j,i) = (x < x0) ? 1.0 : 16.0;
+                  d.dustVc[n](VX1,k,j,i) = (x < x0) ? 2.0 : 0.125;
+                }
+
+
+            }
+        }
+    }
+
+    // Send it all, if needed
+    d.SyncToDevice();
+}
+
+// Analyse data to produce an output
+void MakeAnalysis(DataBlock & data) {
+
+}

--- a/test/Dust/DustyShock/testme.py
+++ b/test/Dust/DustyShock/testme.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+"""
+
+@author: glesur
+"""
+import os
+import sys
+sys.path.append(os.getenv("IDEFIX_DIR"))
+
+import pytools.idfx_test as tst
+
+name="dump.0001.dmp"
+
+def testMe(test):
+  test.configure()
+  test.compile()
+  inifiles=["idefix.ini","idefix-implicit.ini"]
+
+  # loop on all the ini files for this test
+  for ini in inifiles:
+    test.run(inputFile=ini)
+    if test.init:
+      test.makeReference(filename=name)
+    test.standardTest()
+    test.nonRegressionTest(filename=name,tolerance=1e-14)
+
+
+test=tst.idfxTest()
+
+if not test.all:
+  if(test.check):
+    test.checkOnly(filename=name)
+  else:
+    testMe(test)
+else:
+  test.noplot = True
+  test.reconstruction=2
+  testMe(test)

--- a/test/Dust/DustyWave/idefix-implicit.ini
+++ b/test/Dust/DustyWave/idefix-implicit.ini
@@ -1,0 +1,36 @@
+# This test checks the dissipation of a sound wave by a dust grains
+# partially coupled to the gas (Riols & Lesur 2018, appendix A)
+
+[Grid]
+X1-grid    1  0.0  500  u  1.0
+X2-grid    1  0.0  1    u  1.0
+X3-grid    1  0.0  1    u  1.0
+
+[TimeIntegrator]
+CFL         0.8
+tstop       10.0
+first_dt    1.e-4
+nstages     2
+
+[Hydro]
+solver    hllc
+csiso     constant  1.0
+
+[Dust]
+nSpecies         1
+drag             tau  1.0e-3
+drag_feedback    yes
+drag_implicit    yes
+
+[Boundary]
+X1-beg    periodic
+X1-end    periodic
+X2-beg    outflow
+X2-end    outflow
+X3-beg    outflow
+X3-end    outflow
+
+[Output]
+dmp         10.0
+analysis    0.01
+log         1000

--- a/test/Dust/DustyWave/idefix-implicit.ini
+++ b/test/Dust/DustyWave/idefix-implicit.ini
@@ -18,7 +18,7 @@ csiso     constant  1.0
 
 [Dust]
 nSpecies         1
-drag             tau  1.0e-3
+drag             tau  1.0
 drag_feedback    yes
 drag_implicit    yes
 

--- a/test/Dust/DustyWave/python/testidefix.py
+++ b/test/Dust/DustyWave/python/testidefix.py
@@ -35,9 +35,6 @@ sol=np.roots(poly)
 # Get the minimal decay rate (this should be the one that pops up)
 tau=np.amax(np.imag(sol))
 
-
-
-
 # load the dat file produced by the setup
 raw=np.loadtxt('../timevol.dat',skiprows=1)
 t=raw[:,0]
@@ -58,10 +55,10 @@ if not(args.noplot):
 # Compute decay rate:
 tau_measured=t[-1]/(2*np.log(etot[-1]/etot[0]))
 # error on the decay rate:
-error=(tau_measured-tau)/tau
+error=np.abs((tau_measured-tau)/tau)
 
 print("error=%f"%error)
-if(error<0.065):
+if(error<0.07):
   print("Success!")
 else:
   print("Failure!")

--- a/test/Dust/DustyWave/testme.py
+++ b/test/Dust/DustyWave/testme.py
@@ -15,7 +15,7 @@ name="dump.0001.dmp"
 def testMe(test):
   test.configure()
   test.compile()
-  inifiles=["idefix.ini"]
+  inifiles=["idefix.ini","idefix-implicit.ini"]
 
   # loop on all the ini files for this test
   for ini in inifiles:

--- a/test/Dust/FargoPlanet/setup.cpp
+++ b/test/Dust/FargoPlanet/setup.cpp
@@ -42,7 +42,7 @@ void MySoundSpeed(DataBlock &data, const real t, IdefixArray3D<real> &cs) {
 // a = 20 cm *  beta * (Sigma_phys/100 g.cm^-2) / (rho_s / 2 g.cm^-3)
 // NB: checked against A. Johansen+ (2007)
 
-void MyDrag(DataBlock *data, real beta, IdefixArray3D<real> &gamma) {
+void MyDrag(DataBlock *data, int nSpecie, real beta, IdefixArray3D<real> &gamma) {
   // Compute the drag coefficient gamma from the input beta
   auto x1 = data->x[IDIR];
   real sigma0 = sigma0Glob;


### PR DESCRIPTION
This PR implements an IMEX1 implicit scheme to evolve multi-species (eg dust) systems without affecting the timestep.

It also adds the DustShock test to the dust test suite (that already contains DustyWave, DustEnergy, Streaming Instability and Fargo)

Also fix #320 

Thanks to @alexziab for validating the implicit solver against Takeushi & Lin (2002) drift solutions.