### PR TITLE
fix RKL in grids with small spacing

### DIFF
--- a/src/fluid/calcRightHandSide.hpp
+++ b/src/fluid/calcRightHandSide.hpp
@@ -162,9 +162,7 @@ struct Fluid_CorrectFluxFunctor {
         // Conserve angular momentum, hence flux is R*Bphi
         Flux(iMPHI,k,j,i) = Flux(iMPHI,k,j,i) * FABS(x1m(i));
         if constexpr(Phys::mhd) {
-          if(Ax<SMALL_NUMBER) Ax=SMALL_NUMBER;    //avoid singularity around poles
-          // No area for this one
-          Flux(iBPHI,k,j,i) = Flux(iBPHI,k,j,i) / Ax;
+          if(Ax>0) Flux(iBPHI,k,j,i) = Flux(iBPHI,k,j,i) / Ax;    //avoid singularity around poles
         }
       }
 #endif // GEOMETRY==POLAR OR CYLINDRICAL
@@ -175,17 +173,17 @@ struct Fluid_CorrectFluxFunctor {
         Flux(iMPHI,k,j,i) = Flux(iMPHI,k,j,i) * FABS(x1m(i));
   #endif // COMPONENTS == 3
         if constexpr(Phys::mhd) {
-          if(Ax<SMALL_NUMBER) Ax=SMALL_NUMBER;    // avoid singularity around poles
-          EXPAND(                                            ,
-              Flux(iBTH,k,j,i)  = Flux(iBTH,k,j,i) * x1m(i) / Ax;  ,
-              Flux(iBPHI,k,j,i) = Flux(iBPHI,k,j,i) * x1m(i) / Ax; )
+          if(Ax>0) {    // avoid singularity around poles
+            EXPAND(                                            ,
+                Flux(iBTH,k,j,i)  = Flux(iBTH,k,j,i) * x1m(i) / Ax;  ,
+                Flux(iBPHI,k,j,i) = Flux(iBPHI,k,j,i) * x1m(i) / Ax; )
+          }
         }
       } else if constexpr (dir==JDIR) {
   #if COMPONENTS == 3
         Flux(iMPHI,k,j,i) = Flux(iMPHI,k,j,i) * FABS(sinx2m(j));
         if constexpr(Phys::mhd) {
-          if(Ax<SMALL_NUMBER) Ax=SMALL_NUMBER;    // avoid singularity around poles
-          Flux(iBPHI,k,j,i) = Flux(iBPHI,k,j,i)  / Ax;
+          if(Ax>0) Flux(iBPHI,k,j,i) = Flux(iBPHI,k,j,i)  / Ax; // avoid singularity around poles
         }
   #endif // COMPONENTS = 3
       }

--- a/src/rkl/rkl.hpp
+++ b/src/rkl/rkl.hpp
@@ -763,11 +763,6 @@ void RKLegendre<Phys>::CalcParabolicRHS(real t) {
     KOKKOS_LAMBDA (int n, int k, int j, int i) {
       real Ax = A(k,j,i);
 
-#if GEOMETRY != CARTESIAN
-      if(Ax<SMALL_NUMBER)
-        Ax=SMALL_NUMBER;    // Essentially to avoid singularity around poles
-#endif
-
       const int nv = varList(n);
 
       Flux(nv,k,j,i) = Flux(nv,k,j,i) * Ax;

--- a/src/rkl/rkl.hpp
+++ b/src/rkl/rkl.hpp
@@ -835,12 +835,15 @@ void RKLegendre<Phys>::CalcParabolicRHS(real t) {
         rhs /= x1(i);
       }
     #endif // iMPHI
+    real dx_ = dx(i);
+    real x1_ = x1(i);
+
     if constexpr(Phys::mhd) {
       #if (GEOMETRY == POLAR || GEOMETRY == CYLINDRICAL) &&  (defined iBPHI)
-        if(nv==iBPHI) rhs = - 1 / dx(i) * (Flux(iBPHI, k, j, i+1) - Flux(iBPHI, k, j, i) );
+        if(nv==iBPHI) rhs = - 1 / dx_ * (Flux(iBPHI, k, j, i+1) - Flux(iBPHI, k, j, i) );
 
       #elif (GEOMETRY == SPHERICAL)
-        real q = 1 / (x1(i)*dx(i));
+        real q = 1 / (x1_*dx_);
         if(nv == BX2 || nv == BX3) {
           rhs = -q * ((Flux(nv, k, j, i+1)  - Flux(nv, k, j, i) ));
         }
@@ -852,9 +855,11 @@ void RKLegendre<Phys>::CalcParabolicRHS(real t) {
       if(nv == iMPHI) {
         rhs /= FABS(s(j));
       }
+      real dx_ = dx(j);
+      real rt_ = rt(i);
       if constexpr(Phys::mhd) {
         if(nv == iBPHI) {
-          rhs = - 1 / (rt(i)*dx(j)) * (Flux(nv, k, j+1, i) - Flux(nv, k, j, i));
+          rhs = - 1 / (rt_*dx_) * (Flux(nv, k, j+1, i) - Flux(nv, k, j, i));
         }
       }
     #endif // GEOMETRY

--- a/src/rkl/rkl.hpp
+++ b/src/rkl/rkl.hpp
@@ -772,7 +772,7 @@ void RKLegendre<Phys>::CalcParabolicRHS(real t) {
     || (GEOMETRY == CYLINDRICAL && COMPONENTS == 3)
       if(dir==IDIR) {
         if(nv==iMPHI) {
-          Flux(iMPHI,k,j,i) = Flux(iMPHI,k,j,i) * FABS(x1(i));
+          Flux(iMPHI,k,j,i) = Flux(iMPHI,k,j,i) * FABS(x1m(i));
         }
         if constexpr(Phys::mhd) {
           if(nv==iBPHI) {


### PR DESCRIPTION
fix a bug that could lead to Nans when using the RKL scheme on grids with small grid spacing (<1e-5) as discussed in #322 

additionally correct the curvature terms on cell-centered B that were not properly taken into account in the RKL loop. This can affect the outcome of simulations using the RKL scheme for Ohmic or Ambipolar diffusion in 2.5D non-cartesian models (NB: full 3D models are not affected since B is entirely computed by the CT scheme in these cases)
