### PR TITLE
Walltime dumps

### DIFF
--- a/doc/source/reference/idefix.ini.rst
+++ b/doc/source/reference/idefix.ini.rst
@@ -388,8 +388,10 @@ This section describes the outputs *Idefix* produces. For more details about eac
 +================+=========================+==================================================================================================+
 | log            | integer                 | | Time interval between log outputs, in code steps (default 100).                                |
 +----------------+-------------------------+--------------------------------------------------------------------------------------------------+
-| dmp            | float                   | | Time interval between dump outputs, in code units.                                             |
-|                |                         | | If negative, periodic dump outputs are disabled.                                               |
+| dmp            | float, float+char       | | 1st parameter: Code time interval between dump outputs, in code units.                         |
+|                |                         | | If negative, the first parameter is ignored.                                                   |
+|                |                         | | 2nd parameter (optional): Wallclock time interval between two dumps. The ending character      |
+|                |                         | | can be "s" (seconds) "m" (minutes) "h" (hours) or "d" (days)                                   |
 +----------------+-------------------------+--------------------------------------------------------------------------------------------------+
 | dmp_dir        | string                  | | directory for dump file outputs. Default to "./"                                               |
 |                |                         | | The directory is automatically created if it does not exist.                                   |

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -55,8 +55,13 @@ Output::Output(Input &input, DataBlock &data)
     dumpPeriod = input.Get<real>("Output","dmp",0);
     dumpLast = data.t - dumpPeriod; // dump something in the next CheckForWrite()
     if(input.CheckEntry("Output","dmp")>1) {
-      dumpTimePeriod = input.Get<real>("Output","dmp",1);
-      std::string dumpTimeExtension = input.Get<std::string>("Output","dmp",2);
+      std::string dumpString = input.Get<std::string>("Output","dmp",1);
+      try {
+        dumpTimePeriod = std::stod(dumpString.substr(0, dumpString.size()-1), NULL);
+      } catch(const std::exception& e) {
+        IDEFIX_ERROR("The dump time period should be a number followed by a unit (s, m, h or d)");
+      }
+      std::string dumpTimeExtension = dumpString.substr(dumpString.size()-1,1);
       if(dumpTimeExtension.compare("s")==0) {
         dumpTimePeriod *= 1.0;  // Dump time period is in seconds by default
       } else if (dumpTimeExtension.compare("m")==0) {


### PR DESCRIPTION
Improve Wallclock dump outputs and add documentation (this feature has been around since 2.0.05, but not referenced)