### PR TITLE
fix profiling on GPUs

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -66,6 +66,7 @@ int initialize() {
 void pushRegion(const std::string& kName) {
   Kokkos::Profiling::pushRegion(kName);
   if(prof.perfEnabled) {
+    Kokkos::fence();
     prof.currentRegion = prof.currentRegion->GetChild(kName);
     prof.currentRegion->Start();
   }


### PR DESCRIPTION
fix #339 

Add `Kokkos::fence` at the beginning of profiling regions to fix profiling incorrect timing on GPUs
