### PR TITLE
fix the energetic of ShearingBox+Fargo

### DIFF
--- a/src/fluid/addSourceTerms.hpp
+++ b/src/fluid/addSourceTerms.hpp
@@ -85,6 +85,9 @@ struct Fluid_AddSourceTermsFunctor {
       }
       if(haveFargo) {
         Uc(MX1,k,j,i) +=   TWO_F * dt * Vc(RHO,k,j,i) * OmegaZ * sbS * x1(i);
+        if constexpr(Phys::pressure) {
+          Uc(ENG,k,j,i) +=   TWO_F * dt * Vc(RHO,k,j,i) * OmegaZ * sbS * x1(i) * Vc(VX1,k,j,i);
+        }
       }
     #endif
       // fetch fargo velocity when required


### PR DESCRIPTION
The work done by the gravity force in shearing box was not properly removed when using fargo  (cf #344 ). This led to incorrect energetics. This PR fixes this issue