### PR TITLE
fix "size" drag force 

### DIFF
--- a/src/fluid/drag.hpp
+++ b/src/fluid/drag.hpp
@@ -37,8 +37,8 @@ class GammaDrag {
       // Assume a fixed size, hence for both Epstein or Stokes, gamma~1/rho_g/cs
       // Get the sound speed
       #if HAVE_ENERGY == 1
-        cs = std::sqrt(eos.GetGamma(VcGas(PRS,k,j,i),VcGas(RHO,k,j,i)
-                        *VcGas(PRS,k,j,i)/VcGas(RHO,k,j,i)));
+        cs = std::sqrt(  eos.GetGamma(VcGas(PRS,k,j,i),VcGas(RHO,k,j,i))
+                        *VcGas(PRS,k,j,i)/VcGas(RHO,k,j,i));
       #else
         cs = eos.GetWaveSpeed(k,j,i);
       #endif


### PR DESCRIPTION
fix #352 
The "size" drag force, used notably for modeling dust grains, was not computed correctly when an adiabatic equation of state was used (the sound speed was not properly computed). This PR fixes this issue.

NB: this does not affect results when using a "userdef" drag force, or when using a "ISOTHERMAL" equation of state.