### PR TITLE
Fix axis regularisation

### DIFF
--- a/src/fluid/boundary/axis.cpp
+++ b/src/fluid/boundary/axis.cpp
@@ -52,7 +52,7 @@ void Axis::SymmetrizeEx1Side(int jref) {
   KOKKOS_LAMBDA(int k,int i) {
     Ex1(k,jref,i) = Ex1Avg(i)/((real) ncells);
   });
-  
+
 #endif
 }
 

--- a/src/fluid/boundary/axis.cpp
+++ b/src/fluid/boundary/axis.cpp
@@ -28,39 +28,31 @@ void Axis::SymmetrizeEx1Side(int jref) {
   IdefixArray3D<real> Ex1 = this->ex;
   IdefixArray1D<real> Ex1Avg = this->Ex1Avg;
 
-  if(isTwoPi) {
-    idefix_for("Ex1_ini",0,data->np_tot[IDIR],
-        KOKKOS_LAMBDA(int i) {
-          Ex1Avg(i) = ZERO_F;
-        });
-
-    idefix_for("Ex1_Symmetrize",data->beg[KDIR],data->end[KDIR],0,data->np_tot[IDIR],
-      KOKKOS_LAMBDA(int k,int i) {
-        Kokkos::atomic_add(&Ex1Avg(i),  Ex1(k,jref,i));
+  idefix_for("Ex1_ini",0,data->np_tot[IDIR],
+      KOKKOS_LAMBDA(int i) {
+        Ex1Avg(i) = ZERO_F;
       });
-    if(needMPIExchange) {
-      #ifdef WITH_MPI
-        Kokkos::fence();
-        // sum along all of the processes on the same r
-        MPI_Allreduce(MPI_IN_PLACE, Ex1Avg.data(), data->np_tot[IDIR], realMPI,
-                      MPI_SUM, data->mygrid->AxisComm);
-      #endif
-    }
 
-    int ncells=data->mygrid->np_int[KDIR];
-
-    idefix_for("Ex1_Store",0,data->np_tot[KDIR],0,data->np_tot[IDIR],
+  idefix_for("Ex1_Symmetrize",data->beg[KDIR],data->end[KDIR],0,data->np_tot[IDIR],
     KOKKOS_LAMBDA(int k,int i) {
-      Ex1(k,jref,i) = Ex1Avg(i)/((real) ncells);
+      Kokkos::atomic_add(&Ex1Avg(i),  Ex1(k,jref,i));
     });
-  } else {
-    // if we're not doing full two pi, the flow is symmetric with respect to the axis, and the axis
-    // EMF is simply zero
-    idefix_for("Ex1_Store",0,data->np_tot[KDIR],0,data->np_tot[IDIR],
-    KOKKOS_LAMBDA(int k,int i) {
-      Ex1(k,jref,i) = ZERO_F;
-    });
+  if(needMPIExchange) {
+    #ifdef WITH_MPI
+      Kokkos::fence();
+      // sum along all of the processes on the same r
+      MPI_Allreduce(MPI_IN_PLACE, Ex1Avg.data(), data->np_tot[IDIR], realMPI,
+                    MPI_SUM, data->mygrid->AxisComm);
+    #endif
   }
+
+  int ncells=data->mygrid->np_int[KDIR];
+
+  idefix_for("Ex1_Store",0,data->np_tot[KDIR],0,data->np_tot[IDIR],
+  KOKKOS_LAMBDA(int k,int i) {
+    Ex1(k,jref,i) = Ex1Avg(i)/((real) ncells);
+  });
+  
 #endif
 }
 
@@ -100,9 +92,9 @@ void Axis::RegularizeCurrentSide(int side) {
       sign = -1;
     }
     IdefixArray1D<real> BAvg = this->Ex1Avg;
-    IdefixArray1D<real> x2 = data->x[JDIR];
     IdefixArray1D<real> x1 = data->x[IDIR];
     IdefixArray1D<real> dx3 = data->dx[KDIR];
+    IdefixArray1D<real> dx2 = data->dx[JDIR];
 
     idefix_for("B_ini",0,data->np_tot[IDIR],
           KOKKOS_LAMBDA(int i) {
@@ -132,8 +124,7 @@ void Axis::RegularizeCurrentSide(int side) {
 
     idefix_for("fixJ",0,data->np_tot[KDIR],0,data->np_tot[IDIR],
         KOKKOS_LAMBDA(int k,int i) {
-          real th = x2(jc);
-          real fact = 2*sign/(deltaPhi*x1(i)*sin(th));
+          real fact = 2*sign/(deltaPhi*x1(i)*dx2(jc));
           J(IDIR, k,js,i) = BAvg(i)*fact;
         });
 

--- a/src/fluid/calcRightHandSide.hpp
+++ b/src/fluid/calcRightHandSide.hpp
@@ -363,7 +363,7 @@ struct Fluid_CalcRHSFunctor {
         #if (GEOMETRY == SPHERICAL) && (COMPONENTS == 3)
           rhs[iMPHI] /= FABS(sinx2(j));
           if constexpr(Phys::mhd) {
-            rhs[iBPHI] = -dt / (rt(i)*dx(j)) * (Flux(iBPHI, k, j+1, i) - Flux(iBPHI, k, j, i));
+            rhs[iBPHI] = -dt / (x1(i)*dx(j)) * (Flux(iBPHI, k, j+1, i) - Flux(iBPHI, k, j, i));
           } // MHD
         #endif // GEOMETRY
       }

--- a/test/IO/pydefix/README.md
+++ b/test/IO/pydefix/README.md
@@ -43,7 +43,7 @@ export pybind11_DIR=env/lib/python3.10/site-packages/pybind11
 
 you can then run cmake which should be able to find pybind11, and compile the code.
 
-If while running the code using a python interpreter in an envionement, you might run into errors stating that some module
+If while running the code using a python interpreter in an environment, you run into errors stating that some module
 installed in your environement is not present. This is because pybind11 does not always capture your venv. You need to force the following environement variables (replace XX by your python version)
 
 ```bash

--- a/test/IO/pydefix/README.md
+++ b/test/IO/pydefix/README.md
@@ -47,5 +47,5 @@ If while running the code using a python interpreter in an environment, you run 
 installed in your environement is not present. This is because pybind11 does not always capture your venv. You need to force the following environement variables (replace XX by your python version)
 
 ```bash
-export PYTHONPATH=$VIRTUAL_ENV/lib/python3.XX/site-packages
+export PYTHONPATH=$VIRTUAL_ENV/lib/python3.XX/site-packages:$PYTHONPATH
 ```

--- a/test/IO/pydefix/README.md
+++ b/test/IO/pydefix/README.md
@@ -42,3 +42,10 @@ export pybind11_DIR=env/lib/python3.10/site-packages/pybind11
 ```
 
 you can then run cmake which should be able to find pybind11, and compile the code.
+
+If while running the code using a python interpreter in an envionement, you might run into errors stating that some module
+installed in your environement is not present. This is because pybind11 does not always capture your venv. You need to force the following environement variables (replace XX by your python version)
+
+```bash
+export PYTHONPATH=$VIRTUAL_ENV/lib/python3.XX/site-packages
+```


### PR DESCRIPTION
Various fix to ensure that temporal evolution is exactly identical in spherical 2.5D and 3D (non 2pi) and 3D (2pi) in non-ideal MHD.
- Ensure Ex1 regularisation is applied even when azimuthal domain is non-2pi (as Ex1 can be non-zero on the axis in non-ideal MHD)
- Ensure Jx1 regularisation on the axis (circulation around the axis) is consistent with the discretisation used to compute the electrical current in the rest of the domain
- Ensure Bphi evolution in 2.5D (using cell-centered fluxes)  is consistent with the evolution using full CT in 3D (using edge-centered EMFs).