### PR TITLE
[FIX] compatibility with compiling on AMD Instinct MI300A APU

### DIFF
--- a/src/dataBlock/dataBlockHost.cpp
+++ b/src/dataBlock/dataBlockHost.cpp
@@ -21,11 +21,11 @@ DataBlockHost::DataBlockHost(DataBlock& datain) {
 
   // Create mirrors (should be mirror_view)
   for(int dir = 0 ; dir < 3 ; dir++) {
-    x[dir] = Kokkos::create_mirror_view(data->x[dir]);
-    xr[dir] = Kokkos::create_mirror_view(data->xr[dir]);
-    xl[dir] = Kokkos::create_mirror_view(data->xl[dir]);
-    dx[dir] = Kokkos::create_mirror_view(data->dx[dir]);
-    A[dir] = Kokkos::create_mirror_view(data->A[dir]);
+    x[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->x[dir]);
+    xr[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->xr[dir]);
+    xl[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->xl[dir]);
+    dx[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->dx[dir]);
+    A[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->A[dir]);
   }
 
   np_tot = data->np_tot;
@@ -47,30 +47,30 @@ DataBlockHost::DataBlockHost(DataBlock& datain) {
 
     // TO BE COMPLETED...
 
-  dV = Kokkos::create_mirror_view(data->dV);
-  Vc = Kokkos::create_mirror_view(data->hydro->Vc);
-  Uc = Kokkos::create_mirror_view(data->hydro->Uc);
-  InvDt = Kokkos::create_mirror_view(data->hydro->InvDt);
+  dV = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->dV);
+  Vc = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->Vc);
+  Uc = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->Uc);
+  InvDt = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->InvDt);
 
 #if MHD == YES
-  Vs = Kokkos::create_mirror_view(data->hydro->Vs);
+  Vs = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->Vs);
   this->haveCurrent = data->hydro->haveCurrent;
   if(data->hydro->haveCurrent) {
-    J = Kokkos::create_mirror_view(data->hydro->J);
+    J = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->J);
   }
   #ifdef EVOLVE_VECTOR_POTENTIAL
-    Ve = Kokkos::create_mirror_view(data->hydro->Ve);
+    Ve = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->Ve);
   #endif
 
-  D_EXPAND( Ex3 = Kokkos::create_mirror_view(data->hydro->emf->ez);  ,
+  D_EXPAND( Ex3 = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->emf->ez);  ,
                                                              ,
-            Ex1 = Kokkos::create_mirror_view(data->hydro->emf->ex);
-            Ex2 = Kokkos::create_mirror_view(data->hydro->emf->ey);  )
+            Ex1 = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->emf->ex);
+            Ex2 = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->hydro->emf->ey);  )
 #endif
   if(haveDust) {
     dustVc = std::vector<IdefixHostArray4D<real>>(data->dust.size());
     for(int i = 0 ; i < data->dust.size() ; i++) {
-      dustVc[i] = Kokkos::create_mirror_view(data->dust[i]->Vc);
+      dustVc[i] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->dust[i]->Vc);
     }
   }
 
@@ -80,7 +80,7 @@ DataBlockHost::DataBlockHost(DataBlock& datain) {
     this->coarseningDirection = data->coarseningDirection;
     for(int dir = 0 ; dir < 3 ; dir++) {
       if(coarseningDirection[dir]) {
-        coarseningLevel[dir] = Kokkos::create_mirror_view(data->coarseningLevel[dir]);
+        coarseningLevel[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->coarseningLevel[dir]);
       }
     }
   }

--- a/src/dataBlock/dataBlockHost.cpp
+++ b/src/dataBlock/dataBlockHost.cpp
@@ -80,7 +80,8 @@ DataBlockHost::DataBlockHost(DataBlock& datain) {
     this->coarseningDirection = data->coarseningDirection;
     for(int dir = 0 ; dir < 3 ; dir++) {
       if(coarseningDirection[dir]) {
-        coarseningLevel[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), data->coarseningLevel[dir]);
+        coarseningLevel[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+                                                          data->coarseningLevel[dir]);
       }
     }
   }

--- a/src/dataBlock/dumpToFile.cpp
+++ b/src/dataBlock/dumpToFile.cpp
@@ -45,14 +45,14 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
 
   // TODO(lesurg) Make datablock a friend of hydro to get the Riemann flux?
-  //IdefixArray4D<real>::HostMirror locFlux = Kokkos::create_mirror_view(this->hydro->FluxRiemann);
+  //IdefixArray4D<real>::HostMirror locFlux = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->FluxRiemann);
   //Kokkos::deep_copy(locFlux, this->FluxRiemann);
 #if MHD == YES
 
 
   IdefixArray4D<real>::HostMirror locJ;
   if(hydro->haveCurrent) {
-    locJ = Kokkos::create_mirror_view(this->hydro->J);
+    locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->J);
     Kokkos::deep_copy(locJ, this->hydro->J);
   }
 #endif
@@ -120,7 +120,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
   // Write Vs
 #if MHD == YES
   // Write Vs
-  IdefixArray4D<real>::HostMirror locVs = Kokkos::create_mirror_view(this->hydro->Vs);
+  IdefixArray4D<real>::HostMirror locVs = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->Vs);
   Kokkos::deep_copy(locVs,this->hydro->Vs);
   dims[0] = this->np_tot[IDIR]+IOFFSET;
   dims[1] = this->np_tot[JDIR]+JOFFSET;
@@ -137,7 +137,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
   dims[2] = this->np_tot[KDIR];
 
   std::snprintf(fieldName,NAMESIZE,"Ex3");
-  IdefixArray3D<real>::HostMirror locE = Kokkos::create_mirror_view(this->hydro->emf->ez);
+  IdefixArray3D<real>::HostMirror locE = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->emf->ez);
   Kokkos::deep_copy(locE,this->hydro->emf->ez);
   WriteVariable(fileHdl, 3, dims, fieldName, locE.data());
 
@@ -152,7 +152,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
 
   if(hydro->haveCurrent) {
-    IdefixArray4D<real>::HostMirror locJ = Kokkos::create_mirror_view(this->hydro->J);
+    IdefixArray4D<real>::HostMirror locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->J);
     Kokkos::deep_copy(locJ,this->hydro->J);
     dims[0] = this->np_tot[IDIR];
     dims[1] = this->np_tot[JDIR];

--- a/src/dataBlock/dumpToFile.cpp
+++ b/src/dataBlock/dumpToFile.cpp
@@ -45,7 +45,8 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
 
   // TODO(lesurg) Make datablock a friend of hydro to get the Riemann flux?
-  //IdefixArray4D<real>::HostMirror locFlux = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->FluxRiemann);
+  //IdefixArray4D<real>::HostMirror locFlux = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+  //                                                                     this->hydro->FluxRiemann);
   //Kokkos::deep_copy(locFlux, this->FluxRiemann);
 #if MHD == YES
 
@@ -120,7 +121,8 @@ void DataBlock::DumpToFile(std::string filebase)  {
   // Write Vs
 #if MHD == YES
   // Write Vs
-  IdefixArray4D<real>::HostMirror locVs = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->Vs);
+  IdefixArray4D<real>::HostMirror locVs = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+                                                                     this->hydro->Vs);
   Kokkos::deep_copy(locVs,this->hydro->Vs);
   dims[0] = this->np_tot[IDIR]+IOFFSET;
   dims[1] = this->np_tot[JDIR]+JOFFSET;
@@ -137,7 +139,8 @@ void DataBlock::DumpToFile(std::string filebase)  {
   dims[2] = this->np_tot[KDIR];
 
   std::snprintf(fieldName,NAMESIZE,"Ex3");
-  IdefixArray3D<real>::HostMirror locE = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->emf->ez);
+  IdefixArray3D<real>::HostMirror locE = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+                                                                    this->hydro->emf->ez);
   Kokkos::deep_copy(locE,this->hydro->emf->ez);
   WriteVariable(fileHdl, 3, dims, fieldName, locE.data());
 
@@ -152,7 +155,8 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
 
   if(hydro->haveCurrent) {
-    IdefixArray4D<real>::HostMirror locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->J);
+    IdefixArray4D<real>::HostMirror locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+                                                                      this->hydro->J);
     Kokkos::deep_copy(locJ,this->hydro->J);
     dims[0] = this->np_tot[IDIR];
     dims[1] = this->np_tot[JDIR];

--- a/src/fluid/checkNan.hpp
+++ b/src/fluid/checkNan.hpp
@@ -67,7 +67,7 @@ int Fluid<Phys>::CheckNan()  {
 
       DataBlockHost dataHost(*data);
 
-      IdefixHostArray4D<real> VcHost = Kokkos::create_mirror_view(this->Vc);
+      IdefixHostArray4D<real> VcHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->Vc);
       Kokkos::deep_copy(VcHost,Vc);
 
       int nerrormax=10;
@@ -95,7 +95,7 @@ int Fluid<Phys>::CheckNan()  {
       }
 
       if constexpr(Phys::mhd) {
-        IdefixHostArray4D<real> VsHost = Kokkos::create_mirror_view(this->Vs);
+        IdefixHostArray4D<real> VsHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->Vs);
         Kokkos::deep_copy(VsHost,Vs);
         for(int k = data->beg[KDIR] ; k < data->end[KDIR]+KOFFSET ; k++) {
           for(int j = data->beg[JDIR] ; j < data->end[JDIR]+JOFFSET ; j++) {

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -39,7 +39,7 @@ template<typename T>
 IdefixArray1D<T> ConvertVectorToIdefixArray(std::vector<T> &inputVector) {
   IdefixArray1D<T> outArr = IdefixArray1D<T>("Vector",inputVector.size());
   IdefixHostArray1D<T> outArrHost;
-  outArrHost = Kokkos::create_mirror_view(outArr);
+  outArrHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), outArr);
   for(int i = 0; i < inputVector.size() ; i++) {
     outArrHost(i) = inputVector[i];
   }

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -81,7 +81,7 @@ class SubGrid {
           parentGrid(grid), type(type), direction(d) {
             idfx::pushRegion("SubGrid::SubGrid()");
             // Find the index of the current subgrid.
-            auto x = Kokkos::create_mirror_view(parentGrid->x[direction]);
+            auto x = Kokkos::create_mirror_view(Kokkos::HostSpace(), parentGrid->x[direction]);
             Kokkos::deep_copy(x,parentGrid->x[direction]);
             int iref = -1;
             for(int i = 0 ; i < x.extent(0) - 1 ; i++) {

--- a/src/gridHost.cpp
+++ b/src/gridHost.cpp
@@ -32,10 +32,10 @@ GridHost::GridHost(Grid &grid) {
 
   // Create mirrors on host
   for(int dir = 0 ; dir < 3 ; dir++) {
-    x[dir] = Kokkos::create_mirror_view(grid.x[dir]);
-    xr[dir] = Kokkos::create_mirror_view(grid.xr[dir]);
-    xl[dir] = Kokkos::create_mirror_view(grid.xl[dir]);
-    dx[dir] = Kokkos::create_mirror_view(grid.dx[dir]);
+    x[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), grid.x[dir]);
+    xr[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), grid.xr[dir]);
+    xl[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), grid.xl[dir]);
+    dx[dir] = Kokkos::create_mirror_view(Kokkos::HostSpace(), grid.dx[dir]);
   }
 
   idfx::popRegion();

--- a/src/output/dump.hpp
+++ b/src/output/dump.hpp
@@ -88,13 +88,13 @@ class DumpField {
                                         h4Darray, var, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
         return(arr3D);
       } else if(arrayType==Device3D) {
-        IdefixHostArray3D<real> arr3D = Kokkos::create_mirror(d3Darray);
+        IdefixHostArray3D<real> arr3D = Kokkos::create_mirror(Kokkos::HostSpace(), d3Darray);
         Kokkos::deep_copy(arr3D,d3Darray);
         return(arr3D);
       } else if(arrayType==Device4D) {
         IdefixArray3D<real> arrDev3D = Kokkos::subview(
                                        d4Darray, var, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
-        IdefixHostArray3D<real> arr3D = Kokkos::create_mirror(arrDev3D);
+        IdefixHostArray3D<real> arr3D = Kokkos::create_mirror(Kokkos::HostSpace(), arrDev3D);
         Kokkos::deep_copy(arr3D,arrDev3D);
         return(arr3D);
       } else {

--- a/src/output/scalarField.hpp
+++ b/src/output/scalarField.hpp
@@ -33,7 +33,7 @@ class ScalarField {
                                       h4Darray, var, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
       return(arr3D);
     } else if(type==Device3D) {
-      IdefixHostArray3D<real> arr3D = Kokkos::create_mirror(d3Darray);
+      IdefixHostArray3D<real> arr3D = Kokkos::create_mirror(Kokkos::HostSpace(), d3Darray);
       Kokkos::deep_copy(arr3D,d3Darray);
       return(arr3D);
     } else if(type==Device4D) {

--- a/src/utils/lookupTable.hpp
+++ b/src/utils/lookupTable.hpp
@@ -183,10 +183,10 @@ LookupTable<kDim>::LookupTable(std::vector<std::string> filenames,
   this->offsetDev = IdefixArray1D<int> ("Table_offset", kDim);
   this->dataDev =  IdefixArray1D<real> ("Table_data", dataVector.size());
 
-  this->xinHost = Kokkos::create_mirror_view(this->xinDev);
-  this->dimensionsHost = Kokkos::create_mirror_view(this->dimensionsDev);
-  this->offsetHost = Kokkos::create_mirror_view(this->offsetDev);
-  this->dataHost = Kokkos::create_mirror_view(this->dataDev);
+  this->xinHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->xinDev);
+  this->dimensionsHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->dimensionsDev);
+  this->offsetHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->offsetDev);
+  this->dataHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->dataDev);
 
   // Copy data in memory
   for(uint64_t i = 0 ; i < dataVector.size() ; i++) {
@@ -346,10 +346,10 @@ LookupTable<kDim>::LookupTable(std::string filename, char delimiter, bool errOOB
   this->offsetDev = IdefixArray1D<int> ("Table_offset", kDim);
   this->dataDev =  IdefixArray1D<real> ("Table_data", size[0]*size[1]);
 
-  this->xinHost = Kokkos::create_mirror_view(this->xinDev);
-  this->dimensionsHost = Kokkos::create_mirror_view(this->dimensionsDev);
-  this->offsetHost = Kokkos::create_mirror_view(this->offsetDev);
-  this->dataHost = Kokkos::create_mirror_view(this->dataDev);
+  this->xinHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->xinDev);
+  this->dimensionsHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->dimensionsDev);
+  this->offsetHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->offsetDev);
+  this->dataHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->dataDev);
 
   // Fill the arrays with the std::vector content
   if(idfx::prank == 0) {
@@ -458,10 +458,10 @@ LookupTable<kDim>::LookupTable(Kokkos::View<T, Args...> array,
   this->offsetDev = IdefixArray1D<int> ("Table_offset", kDim);
   this->dataDev =  IdefixArray1D<real> ("Table_data", sizeTotal);
 
-  this->xinHost = Kokkos::create_mirror_view(this->xinDev);
-  this->dimensionsHost = Kokkos::create_mirror_view(this->dimensionsDev);
-  this->offsetHost = Kokkos::create_mirror_view(this->offsetDev);
-  this->dataHost = Kokkos::create_mirror_view(this->dataDev);
+  this->xinHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->xinDev);
+  this->dimensionsHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->dimensionsDev);
+  this->offsetHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->offsetDev);
+  this->dataHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->dataDev);
 
   // Copy data in memory
   for(uint64_t n = 0 ; n < sizeTotal ; n++) {


### PR DESCRIPTION
Here are all the changes that I had to do for getting Idefix compiled on AMD Instinct MI300A APU system that powers MPCDF's Viper cluster (https://docs.mpcdf.mpg.de/doc/computing/viper-gpu-user-guide.html). 
Many of the `create_mirror` in the code had to include `Kokkos::HostSpace()` however not all. In fact, the compilation fails if it is added to the ones which aren't touched in this PR (don't know the reason).