### PR TITLE
Add vector potentiel to pydefix

### DIFF
--- a/src/output/dump.cpp
+++ b/src/output/dump.cpp
@@ -71,7 +71,7 @@ void Dump::CreateMPIDataType(GridBox gb, bool read) {
     int size[3];
     int subsize[3];
 
-    // the grid is required to now the current MPÏ domain decomposition
+    // the grid is required to know the current MPÏ domain decomposition
     Grid *grid = data->mygrid;
 
     // Dimensions for cell-centered fields

--- a/src/pydefix.cpp
+++ b/src/pydefix.cpp
@@ -228,6 +228,11 @@ PYBIND11_EMBEDDED_MODULE(pydefix, m) {
         m.attr("BX1s") = BX1s; ,
         m.attr("BX2s") = BX2s; ,
         m.attr("BX3s") = BX3s; )
+      #ifdef EVOLVE_VECTOR_POTENTIAL
+        m.attr("AX1e") = AX1e;
+        m.attr("AX2e") = AX2e;
+        m.attr("AX3e") = AX3e;
+      #endif
     #endif
     m.attr("IDIR") = IDIR;
     m.attr("JDIR") = JDIR;


### PR DESCRIPTION
indices AX1e, AX2e and AX3e were missing in pydefix when using vector potential