### PR TITLE
fix incorrect subviews when using vector_potential in 2.5D

### DIFF
--- a/src/fluid/constrainedTransport/enforceVectorPotentialBoundary.hpp
+++ b/src/fluid/constrainedTransport/enforceVectorPotentialBoundary.hpp
@@ -22,7 +22,7 @@ void ConstrainedTransport<Phys>::EnforceVectorPotentialBoundary(IdefixArray4D<re
       Ax2 = Kokkos::subview(Vein, AX2e, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
     #endif
     Ax3 = Kokkos::subview(Vein, AX3e, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-      
+
 
     if(this->hydro->haveAxis) {
       this->hydro->boundary->axis->RegularizeEMFs(Ax1, Ax2, Ax3);

--- a/src/fluid/constrainedTransport/enforceVectorPotentialBoundary.hpp
+++ b/src/fluid/constrainedTransport/enforceVectorPotentialBoundary.hpp
@@ -13,23 +13,31 @@ template<typename Phys>
 void ConstrainedTransport<Phys>::EnforceVectorPotentialBoundary(IdefixArray4D<real> &Vein) {
   idfx::pushRegion("Emf::EnforceVectorPotentialBoundary");
 
-  auto Ax1 = Kokkos::subview(Vein, IDIR, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-  auto Ax2 = Kokkos::subview(Vein, JDIR, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-  auto Ax3 = Kokkos::subview(Vein, KDIR, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
 
-  if(this->hydro->haveAxis) {
-    this->hydro->boundary->axis->RegularizeEMFs(Ax1, Ax2, Ax3);
-  }
+  IdefixArray3D<real> Ax1, Ax2, Ax3;
 
-  #ifdef ENFORCE_EMF_CONSISTENCY
-    #ifdef WITH_MPI
-      // This average the vector potential at the domain surface with immediate neighbours
-      // to ensure the vector potentials exactly match
-
-      this->ExchangeAll(Ax1, Ax2, Ax3);
+  #ifdef EVOLVE_VECTOR_POTENTIAL
+    #if DIMENSIONS == 3
+      Ax1 = Kokkos::subview(Vein, AX1e, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+      Ax2 = Kokkos::subview(Vein, AX2e, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
     #endif
-    EnforceEMFBoundaryPeriodic(Ax1, Ax2, Ax3);
-  #endif
+    Ax3 = Kokkos::subview(Vein, AX3e, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+      
+
+    if(this->hydro->haveAxis) {
+      this->hydro->boundary->axis->RegularizeEMFs(Ax1, Ax2, Ax3);
+    }
+
+    #ifdef ENFORCE_EMF_CONSISTENCY
+      #ifdef WITH_MPI
+        // This average the vector potential at the domain surface with immediate neighbours
+        // to ensure the vector potentials exactly match
+
+        this->ExchangeAll(Ax1, Ax2, Ax3);
+      #endif
+      EnforceEMFBoundaryPeriodic(Ax1, Ax2, Ax3);
+    #endif
+  #endif // EVOLVE_VECTOR_POTENTIAL
 
   idfx::popRegion();
 }


### PR DESCRIPTION
fix a bug that led to the generation of incorrect subviews in 2.5D with vector_potential enabled. Note that this bug was silent, and is detected only when Kokkos_DEBUG is enabled.
