### PR TITLE
fix UCT HLLD when using DIMENSIONS<COMPONENTS

### DIFF
--- a/src/fluid/RiemannSolver/MHDsolvers/storeFlux.hpp
+++ b/src/fluid/RiemannSolver/MHDsolvers/storeFlux.hpp
@@ -87,9 +87,9 @@ KOKKOS_FORCEINLINE_FUNCTION void K_StoreHLLD( const int i, const int j, const in
                                         const IdefixArray3D<real> &aR,
                                         const IdefixArray3D<real> &dL,
                                         const IdefixArray3D<real> &dR) {
-  EXPAND( const int Xn = DIR+MX1;                    ,
-        const int Xt = (DIR == IDIR ? MX2 : MX1);  ,
-        const int Xb = (DIR == KDIR ? MX2 : MX3);  )
+  EXPAND(                const int Xn = DIR+MX1;                    ,
+                         const int Xt = (DIR == IDIR ? MX2 : MX1);  ,
+        [[maybe_unused]] const int Xb = (DIR == KDIR ? MX2 : MX3);  )
   // Compute magnetic pressure
   [[maybe_unused]] real ptR, ptL;
 

--- a/src/fluid/RiemannSolver/MHDsolvers/storeFlux.hpp
+++ b/src/fluid/RiemannSolver/MHDsolvers/storeFlux.hpp
@@ -201,7 +201,7 @@ KOKKOS_FORCEINLINE_FUNCTION void K_StoreHLLD( const int i, const int j, const in
   }
 
   #if COMPONENTS > 1
-  EXPAND( Et(k,j,i) = -st*(ar*vL[Xt] - al*vR[Xt])*scrh;  ,
+  D_EXPAND( Et(k,j,i) = -st*(ar*vL[Xt] - al*vR[Xt])*scrh;  ,
                                                           ,
           Eb(k,j,i) = -sb*(ar*vL[Xb] - al*vR[Xb])*scrh;  );
   #endif


### PR DESCRIPTION
Fix a bug in the pre-computation of the 2D HLLD Riemann solver that led to segfaults when used in conjunction with DIMENSIONS<COMPONENTS

todo: test this regime in the test suite