### PR TITLE
MNT: upgrade inifix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         - F403 # ignore import *
 
   - repo: https://github.com/neutrinoceros/inifix
-    rev: v5.0.2
+    rev: v6.1.2
     hooks:
       - id: inifix-format
 


### PR DESCRIPTION
This is an out of band upgrade for inifix's pre-commit hooks after I discovered that its dependency tree had grown much larger from under it and with no benefit.
This version has a much more minimal dependency tree, so it's even less likely to break in the future, especially in fresh installs