### PR TITLE
SEC: fix insecure GitHub Actions settings and enable automated audits with zizmor + pre-commit

### DIFF
--- a/.github/workflows/idefix-ci-doc.yml
+++ b/.github/workflows/idefix-ci-doc.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - name: install doxygen
         run: sudo apt-get install -y doxygen
       - name: install python dependencies

--- a/.github/workflows/idefix-ci-doc.yml
+++ b/.github/workflows/idefix-ci-doc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: install doxygen
         run: sudo apt-get install -y doxygen
       - name: install python dependencies

--- a/.github/workflows/idefix-ci-doc.yml
+++ b/.github/workflows/idefix-ci-doc.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
 
+permissions: {}
 
 jobs:
   ReadTheDocs:

--- a/.github/workflows/idefix-ci-jobs.yml
+++ b/.github/workflows/idefix-ci-jobs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Sod test
@@ -40,7 +40,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Viscous flow past cylinder
@@ -54,7 +54,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: MHD Sod test
@@ -72,7 +72,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Ambipolar C Shock
@@ -91,7 +91,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Fargo + planet
@@ -104,7 +104,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Hydro shearing box
@@ -117,7 +117,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Jeans Instability
@@ -136,7 +136,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: 3 body
@@ -157,7 +157,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Energy conservation
@@ -170,7 +170,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: MTI
@@ -187,7 +187,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Run examples test
@@ -198,7 +198,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
       - name: Lookup table

--- a/.github/workflows/idefix-ci-jobs.yml
+++ b/.github/workflows/idefix-ci-jobs.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Sod test
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/sod -all $TESTME_OPTIONS
       - name: Isothermal Sod test
@@ -45,6 +46,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Viscous flow past cylinder
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/ViscousFlowPastCylinder -all $TESTME_OPTIONS
       - name: Viscous disk
@@ -59,6 +61,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: MHD Sod test
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/sod -all $TESTME_OPTIONS
       - name: MHD Isothermal Sod test
@@ -77,6 +80,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Ambipolar C Shock
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/AmbipolarCshock -all $TESTME_OPTIONS
       - name: Ambipolar C Shock 3D
@@ -96,6 +100,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Fargo + planet
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/FargoPlanet -all $TESTME_OPTIONS
       - name: Fargo MHD spherical
@@ -109,6 +114,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Hydro shearing box
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/ShearingBox -all $TESTME_OPTIONS
       - name: MHD shearing box
@@ -122,6 +128,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Jeans Instability
         run: scripts/ci/run-tests $IDEFIX_DIR/test/SelfGravity/JeansInstability -all $TESTME_OPTIONS
       - name: Random sphere spherical
@@ -141,6 +148,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: 3 body
         run: scripts/ci/run-tests $IDEFIX_DIR/test/Planet/Planet3Body -all $TESTME_OPTIONS
       - name: migration
@@ -162,6 +170,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Energy conservation
         run: scripts/ci/run-tests $IDEFIX_DIR/test/Dust/DustEnergy -all $TESTME_OPTIONS
       - name: Dusty wave
@@ -175,6 +184,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: MTI
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/MTI -all $TESTME_OPTIONS
       - name: Spherical anisotropic diffusion
@@ -192,6 +202,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Run examples test
         run: cd test && ./checks_examples.sh $TEST_OPTIONS
 
@@ -203,6 +214,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           submodules: recursive
+          persist-credentials: false
       - name: Lookup table
         run: scripts/ci/run-tests $IDEFIX_DIR/test/utils/lookupTable -all $TESTME_OPTIONS
       - name: Dump Image

--- a/.github/workflows/idefix-ci-jobs.yml
+++ b/.github/workflows/idefix-ci-jobs.yml
@@ -21,6 +21,8 @@ env:
   PYTHONPATH: ${{ github.workspace }}
   IDEFIX_DIR: ${{ github.workspace }}
 
+permissions: {}
+
 jobs:
   ShocksHydro:
     runs-on: self-hosted

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
 
+permissions: {}
+
 jobs:
   Linter:
     # Don't do this in forks

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: 3.x

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -15,12 +15,12 @@ jobs:
     if: ${{ github.repository == 'idefix-code/idefix' || github.repository == 'glesur/idefix' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: 3.x
-      - uses: pre-commit/action@v3.0.0
-      - uses: pre-commit-ci/lite-action@v1.0.0
+      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
+      - uses: pre-commit-ci/lite-action@50143aaf27e2c42e75a5e06185a471d9582e89df # v1.0.0
         if: always()
 
   icc-jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=100'] ## prevent files larger than 100kB from being commited (exclude git lfs files)
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.23.1
+    hooks:
+    - id: zizmor
+
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.2
     hooks:


### PR DESCRIPTION
Fix a handful of insecure default settings from github actions.
I'm intentionally targetting the `master` branch here, though it should *also* be fixed on `develop`

contents:
- **SEC: switch GHA refs to immutable hashes with pinact**
- **SEC: disable default gha permissions**
- **SEC: avoid leaking credentials**
- **SEC: enable security audits with zizmor + pre-commit**

I also recommend updating a couple repo settings
- enable immutable releases (this is on the `settings` landing page)
- require actions to be pinned to a full-length commit SHA (this is on the `settings/actions` page)

Tools used in this PR:
- [`zizmor`](https://docs.zizmor.sh)
- [`pinact`](https://github.com/suzuki-shunsuke/pinact)

ref: https://astral.sh/blog/open-source-security-at-astral