### PR TITLE
Bump up to Kokkos 5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
 
 set(Idefix_VERSION_MAJOR 2)
 set(Idefix_VERSION_MINOR 2)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,11 +20,11 @@ algorithm is essentially the same (but with some major modification to its struc
 ================
 Requirements
 ================
-*Idefix* is written is standard C++17 and does not rely on any external library in serial (non MPI).
+*Idefix* is written is standard C++20 and does not rely on any external library in serial (non MPI).
 
 Compiler
-  *Idefix* requires a C++17 compatible compiler. It has been tested successfully with GCC (>8), Intel compiler suite (>2018) and
-  Clang on both Intel and AMD CPUs. *Idefix* has also been tested on NVIDIA GPUs (Pascal, Volta and Ampere architectures) using the nvcc (>10) compiler, and on AMD GPUs (Radeon Mi50, Mi210, Mi250) using the hipcc compiler.
+  *Idefix* requires a C++20 compatible compiler. It has been tested successfully with GCC (>11), Intel compiler suite (>2022) and
+  Clang on both Intel and AMD CPUs. *Idefix* has also been tested on NVIDIA GPUs (Pascal, Volta and Ampere architectures) using the nvcc (>12) compiler, and on AMD GPUs (Radeon Mi50, Mi210, Mi250, Mi300) using the hipcc compiler.
 
 Kokkos library
   *Idefix* relies internally on the `Kokkos <https://github.com/kokkos/kokkos>`_ library, which is bundled with *Idefix* as a git submodule and compiled on the fly, hence no external installation is required.
@@ -89,6 +89,9 @@ Jean Kempf, Victor Reville, François Rincon
 
 Marc Coiffier
   Continuous integration, automatic benchmarking
+
+Sébastien Valat
+   Continuous integration
 
 ========================
 About this documentation

--- a/doc/source/programmingguide.rst
+++ b/doc/source/programmingguide.rst
@@ -355,13 +355,13 @@ fills the following arrays (essentially grid information) with data from its par
 
 .. code-block:: c++
 
-  IdefixArray1D<real>::HostMirror x[3];   // geometrical central points
-  IdefixArray1D<real>::HostMirror xr[3];  // cell right interface
-  IdefixArray1D<real>::HostMirror xl[3];  // cell left interface
-  IdefixArray1D<real>::HostMirror dx[3];  // cell width
+  IdefixArray1D<real>::host_mirror_type x[3];   // geometrical central points
+  IdefixArray1D<real>::host_mirror_type xr[3];  // cell right interface
+  IdefixArray1D<real>::host_mirror_type xl[3];  // cell left interface
+  IdefixArray1D<real>::host_mirror_type dx[3];  // cell width
 
-  IdefixArray3D<real>::HostMirror dV;     // cell volume
-  IdefixArray3D<real>::HostMirror A[3];   // cell right interface area
+  IdefixArray3D<real>::host_mirror_type dV;     // cell volume
+  IdefixArray3D<real>::host_mirror_type A[3];   // cell right interface area
 
 
 Note however that the physics arrays are not automatically synchronized when ``DataBlockHost`` is
@@ -369,17 +369,17 @@ created, that is:
 
 .. code-block:: c++
 
-  IdefixArray4D<real>::HostMirror Vc;     // Main cell-centered primitive variables index
-  IdefixArray4D<real>::HostMirror Vs;     // Main face-centered primitive variables index
-  IdefixArray4D<real>::HostMirror J;      // Current (only when haveCurrent is enabled)
-  IdefixArray4D<real>::HostMirror Uc;     // Main cell-centered conservative variables
-  IdefixArray3D<real>::HostMirror InvDt;
+  IdefixArray4D<real>::host_mirror_type Vc;     // Main cell-centered primitive variables index
+  IdefixArray4D<real>::host_mirror_type Vs;     // Main face-centered primitive variables index
+  IdefixArray4D<real>::host_mirror_type J;      // Current (only when haveCurrent is enabled)
+  IdefixArray4D<real>::host_mirror_type Uc;     // Main cell-centered conservative variables
+  IdefixArray3D<real>::host_mirror_type InvDt;
 
-  IdefixArray3D<real>::HostMirror Ex1;    // x1 electric field
-  IdefixArray3D<real>::HostMirror Ex2;    // x2 electric field
-  IdefixArray3D<real>::HostMirror Ex3;    // x3 electric field
+  IdefixArray3D<real>::host_mirror_type Ex1;    // x1 electric field
+  IdefixArray3D<real>::host_mirror_type Ex2;    // x2 electric field
+  IdefixArray3D<real>::host_mirror_type Ex3;    // x3 electric field
 
-need to be synchronized *manually*. These IdefixArrays are all defined as ``HostMirror``, implying that they are accessible
+need to be synchronized *manually*. These IdefixArrays are all defined as ``host_mirror_type``, implying that they are accessible
 from the host only. If modifications are performed on the arrays of the
 parent ``DataBlock``, one can call ``DataBlockHost::SyncFromDevice()`` to refresh the host arrays,
 and inversely one can call ``DataBlockHost::SyncToDevice()`` to send data from ``DataBlockHost``

--- a/src/dataBlock/dumpToFile.cpp
+++ b/src/dataBlock/dumpToFile.cpp
@@ -45,13 +45,13 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
 
   // TODO(lesurg) Make datablock a friend of hydro to get the Riemann flux?
-  //IdefixArray4D<real>::HostMirror locFlux = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+  //IdefixArray4D<real>::host_mirror_type locFlux = Kokkos::create_mirror_view(Kokkos::HostSpace(),
   //                                                                     this->hydro->FluxRiemann);
   //Kokkos::deep_copy(locFlux, this->FluxRiemann);
 #if MHD == YES
 
 
-  IdefixArray4D<real>::HostMirror locJ;
+  IdefixArray4D<real>::host_mirror_type locJ;
   if(hydro->haveCurrent) {
     locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(), this->hydro->J);
     Kokkos::deep_copy(locJ, this->hydro->J);
@@ -82,7 +82,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
   fwrite (header, sizeof(char), HEADERSIZE, fileHdl);
 
   // Write Vc
-  IdefixArray4D<real>::HostMirror locVc = Kokkos::create_mirror_view(this->hydro->Vc);
+  IdefixArray4D<real>::host_mirror_type locVc = Kokkos::create_mirror_view(this->hydro->Vc);
   Kokkos::deep_copy(locVc,this->hydro->Vc);
   dims[0] = this->np_tot[IDIR];
   dims[1] = this->np_tot[JDIR];
@@ -94,7 +94,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
   WriteVariable(fileHdl, 4, dims, fieldName, locVc.data());
 
   if (this->gravity->haveSelfGravityPotential) {
-    IdefixArray3D<real>::HostMirror locPot = Kokkos::create_mirror_view(this->gravity->phiP);
+    IdefixArray3D<real>::host_mirror_type locPot = Kokkos::create_mirror_view(this->gravity->phiP);
     Kokkos::deep_copy(locPot, this->gravity->phiP);
 
     dims[3] = 1;
@@ -121,7 +121,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
   // Write Vs
 #if MHD == YES
   // Write Vs
-  IdefixArray4D<real>::HostMirror locVs = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+  IdefixArray4D<real>::host_mirror_type locVs = Kokkos::create_mirror_view(Kokkos::HostSpace(),
                                                                      this->hydro->Vs);
   Kokkos::deep_copy(locVs,this->hydro->Vs);
   dims[0] = this->np_tot[IDIR]+IOFFSET;
@@ -139,7 +139,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
   dims[2] = this->np_tot[KDIR];
 
   std::snprintf(fieldName,NAMESIZE,"Ex3");
-  IdefixArray3D<real>::HostMirror locE = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+  IdefixArray3D<real>::host_mirror_type locE = Kokkos::create_mirror_view(Kokkos::HostSpace(),
                                                                     this->hydro->emf->ez);
   Kokkos::deep_copy(locE,this->hydro->emf->ez);
   WriteVariable(fileHdl, 3, dims, fieldName, locE.data());
@@ -155,7 +155,7 @@ void DataBlock::DumpToFile(std::string filebase)  {
 
 
   if(hydro->haveCurrent) {
-    IdefixArray4D<real>::HostMirror locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(),
+    IdefixArray4D<real>::host_mirror_type locJ = Kokkos::create_mirror_view(Kokkos::HostSpace(),
                                                                       this->hydro->J);
     Kokkos::deep_copy(locJ,this->hydro->J);
     dims[0] = this->np_tot[IDIR];

--- a/src/fluid/boundary/axis.hpp
+++ b/src/fluid/boundary/axis.hpp
@@ -126,7 +126,7 @@ Axis::Axis(Boundary<Phys> *boundary) {
 
   // Init the symmetry array (used to flip the signs of arrays accross the axis)
   symmetryVc = IdefixArray1D<int>("Axis:SymmetryVc",nVar);
-  IdefixArray1D<int>::HostMirror symmetryVcHost = Kokkos::create_mirror_view(symmetryVc);
+  IdefixArray1D<int>::host_mirror_type symmetryVcHost = Kokkos::create_mirror_view(symmetryVc);
   // Init the array
   for (int nv = 0; nv < nVar; nv++) {
     symmetryVcHost(nv) = 1;
@@ -143,7 +143,7 @@ Axis::Axis(Boundary<Phys> *boundary) {
 
   if constexpr(Phys::mhd) {
     symmetryVs = IdefixArray1D<int>("Axis:SymmetryVs",DIMENSIONS);
-    IdefixArray1D<int>::HostMirror symmetryVsHost = Kokkos::create_mirror_view(symmetryVs);
+    IdefixArray1D<int>::host_mirror_type symmetryVsHost = Kokkos::create_mirror_view(symmetryVs);
     // Init the array
     for(int nv = 0; nv < DIMENSIONS; nv++) {
       symmetryVsHost(nv) = 1;

--- a/src/gravity/laplacian.cpp
+++ b/src/gravity/laplacian.cpp
@@ -170,7 +170,7 @@ void Laplacian::InitInternalGrid() {
      });
 
   // Check that all is well
-  IdefixArray1D<real>::HostMirror xH = Kokkos::create_mirror_view(x1l);
+  IdefixArray1D<real>::host_mirror_type xH = Kokkos::create_mirror_view(x1l);
   Kokkos::deep_copy(xH, x1l);
 
   if(xH(0)<0.0) {

--- a/src/mpi/mpi.cpp
+++ b/src/mpi/mpi.cpp
@@ -131,7 +131,7 @@ void Mpi::CheckConfig() {
 
   // Run-time check that we can do a reduce on device arrays
   IdefixArray1D<int64_t> src("MPIChecksrc",1);
-  IdefixArray1D<int64_t>::HostMirror srcHost = Kokkos::create_mirror_view(src);
+  IdefixArray1D<int64_t>::host_mirror_type srcHost = Kokkos::create_mirror_view(src);
 
   if(idfx::prank == 0) {
     srcHost(0) = 0;


### PR DESCRIPTION
This updates the default Kokkos version to 5.1

This update has major consequences as it requires C++20 (while we were only requiring C++17 up to now).

It offers several optimisation for loop unrolling, to be tested in this PR