### PR TITLE
test: add "default" semantic to testme.json files

### DIFF
--- a/doc/source/testing/testLauncher.rst
+++ b/doc/source/testing/testLauncher.rst
@@ -144,7 +144,7 @@ For a single basic configuration one can use :
 .. code-block:: json
 
     {
-        "variants": {
+        "default": {
             "dumpname": "dump.0001.dmp",
             "ini": "idefix.ini",
             "vectPot": false,
@@ -159,7 +159,7 @@ For a single basic configuration one can use :
 Available parameters
 --------------------
 
-The parameters in the ``variants`` dictionnary correspond to the options supported by the
+The parameters in the ``default`` dictionnary correspond to the options supported by the
 :doc:`idfxTest <idfxTest>` script to configure the build and run of *Idefix*.
 
 In addition there is some extra keys which are dedicated to the json interpretation layer :
@@ -195,22 +195,24 @@ In addition there is some extra keys which are dedicated to the json interpretat
 Looping over parameters
 -----------------------
 
-You might want to explore running Idefix within parameter ranges (configuration files, modes).
-For this simply list the values you want as a list. The test script will automatically
-generate all combinations.
+You might want to explore running *Idefix* within parameter ranges (configuration files, modes).
+For this simply list the values you want as a list in tha ``variants`` dictionnary. The test script
+will automatically generate all combinations.
 
 .. code-block:: json
 
     {
-        "variants": {
+        "default": {
             "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini"],
-            "vectPot": [false, true],
             "single": false,
             "reconstruction": 2,
-            "mpi": [false, true],
             "standardTest": false,
             "tolerance": 0
+        },
+        "variants": {
+            "ini": ["idefix.ini","idefix-hll.ini"],
+            "vectPot": [false, true],
+            "mpi": [false, true]
         }
     }
 
@@ -245,25 +247,24 @@ can list several sets as a list. Here using single only on half of the modes.
 .. code-block:: json
 
     {
+        "default": {
+            "dumpname": "dump.0001.dmp",
+            "tolerance": 0
+            "standardTest": false,
+            "reconstruction": 2
+        },
         "variants": [
             {
-                "dumpname": "dump.0001.dmp",
-                "ini": ["idefix.ini"],
+                "ini": "idefix.ini",
                 "vectPot": false,
                 "single": false,
-                "reconstruction": 2,
                 "mpi": [false, true],
-                "standardTest": false,
-                "tolerance": 0
             },{
-                "dumpname": "dump.0001.dmp",
-                "ini": ["idefix-hll.ini"],
+                "ini": "idefix-hll.ini",
                 "vectPot": true,
                 "single": true,
-                "reconstruction": 2,
                 "mpi": [false, true],
-                "standardTest": false,
-                "tolerance": 0
+
             }
         ]
     }
@@ -284,15 +285,17 @@ the order you want to see them composing the test name.
 
     {
         "namings": "ini,single,mpi",
-        "variants": {
+        "default": {
             "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini"],
             "vectPot": false,
-            "single": [false, true],
             "reconstruction": 2,
-            "mpi": [false, true],
             "standardTest": false,
             "tolerance": 0
+        },
+        "variants": {
+            "ini": ["idefix.ini","idefix-hll.ini"],
+            "single": [false, true],
+            "mpi": [false, true],
         }
     }
 
@@ -309,15 +312,17 @@ It is just like if you used and IF statement.
 
     {
         "namings": "ini,single,mpi",
-        "variants": {
+        "default": {
             "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini"],
             "vectPot": false,
-            "single": [false, true],
             "reconstruction": 2,
-            "mpi": [false, true],
             "standardTest": false,
             "tolerance": 0
+        },
+        "variants": {
+            "ini": ["idefix.ini","idefix-hll.ini"],
+            "single": [false, true],
+            "mpi": [false, true],
         },
         "when": {
             "conditions": {
@@ -348,9 +353,9 @@ They are described like :
 .. code-block:: json
 
     {
-        "variants": {
+        "default": {
             "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
+            "ini": "idefix.ini",
             "vectPot": false,
             "single": false,
             "reconstruction": 2,

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 markers=
   default: Test to run by default.
 python_files="test_*.py"
-junit_logging="system-out"
+junit_logging="all"
 junit_log_passing_tests=false

--- a/pytools/idfx_test.py
+++ b/pytools/idfx_test.py
@@ -169,7 +169,7 @@ class idfxTest:
   def applyConfig(self, config: dict={}):
     # check args
     for key, value in config.items():
-      if key not in ['ini', 'testfile', 'testname', 'dumpname']:
+      if key not in ['ini', 'testfile', 'testname', 'dumpname', 'check_file_produced']:
         assert key in self.cmdArgs, f"The given configuration overriding try to set an invalid paramater : {key}={value}"
 
     # override options

--- a/pytools/idfx_test_gen.py
+++ b/pytools/idfx_test_gen.py
@@ -32,7 +32,7 @@ class IdefixDirTestGenerator:
     self.currentTestName = name
 
   # generate the list of configs to run
-  def genTestConfigs(self, names:str, params, whenClauses = {}) -> list:
+  def genTestConfigs(self, names:str, params, whenClauses = {}, defaultConfig: dict = {}) -> list:
     '''
     Generate the the list of configurations as pytest parameters.
     It will unpack the configuration set by looping on all combinations defined
@@ -48,20 +48,24 @@ class IdefixDirTestGenerator:
       whenCaluses (dict|list):
         Provide a set of clauses to apply after unpacking
         the configuration so we can patch some values depending on some others.
+      defaultConfig (dict):
+        The default configuration on top of which to apply the variants.
 
     Returns:
       A list of pytest.param() ready to be fiven to parametrized pytest functions.
     '''
     # get name ordering list
     nameList = names.split(',')
+    if '' in nameList:
+      nameList.remove('')
 
     # gen list of complete configs
     all_configs = []
     if isinstance(params, dict):
-      all_configs += self._genOneConfigSeries(names, params)
+      all_configs += self._genOneConfigSeries(names, params, defaultConfig=defaultConfig)
     elif isinstance(params, list):
       for p in params:
-        all_configs += self._genOneConfigSeries(names, p)
+        all_configs += self._genOneConfigSeries(names, p, defaultConfig=defaultConfig)
     else:
       raise Exception("Should never be called !")
 
@@ -155,7 +159,7 @@ class IdefixDirTestGenerator:
         result.append(v)
     return result
 
-  def _genOneConfigSeries(self, names: str, config: dict) -> list:
+  def _genOneConfigSeries(self, names: str, config: dict, defaultConfig: dict={}) -> list:
     '''
     Generate the the list of configurations as pytest parameters.
     It will unpack the configuration set by looping on all combinations defined
@@ -167,6 +171,8 @@ class IdefixDirTestGenerator:
         name of the file.
       config (dict):
         A configuration set as a dictionnary.
+      defaultConfig (dict):
+        The default configuration to overload with the variant part.
 
     Returns:
       A list of pytest.param() ready to be fiven to parametrized pytest functions.
@@ -179,9 +185,11 @@ class IdefixDirTestGenerator:
     if 'ini' in loopOrder:
       loopOrder.remove('ini')
       loopOrder.append('ini')
+    if '' in loopOrder:
+      loopOrder.remove('')
 
     # init core with everything not a list
-    core = {}
+    core = copy.deepcopy(defaultConfig)
     for key, value in config.items():
       if isinstance(value, list) and key not in DO_NOT_LOOP_ON:
         assert key in nameList, f"All variable parameteres should be ordered in the names list, '{key}' is not."

--- a/pytools/idfx_test_run.py
+++ b/pytools/idfx_test_run.py
@@ -85,20 +85,27 @@ class IdexPytestRunner:
 
           # load json & build the inner test combinations
           with open(testfilePath, 'r') as fp:
+            # load
             test = json.load(fp)
             idefixTestGenerator=IdefixDirTestGenerator(testfilePath, testfileDir)
+
+            # extract default config & when & variants
+            defaultConfig = test.get('default', {})
+            whenClauses = test.get('when', {})
+            variants = test.get('variants', {})
+
             if 'namings' in test:
               namings = test['namings']
-              autoExtracted = idefixTestGenerator.extractNamingParameters(test['variants'])
+              autoExtracted = idefixTestGenerator.extractNamingParameters(variants)
               self._validateNaming(namings, autoExtracted, testfilePath)
             else:
-              namings = idefixTestGenerator.extractNamingParameters(test['variants'])
+              namings = idefixTestGenerator.extractNamingParameters(variants)
 
             # required to simplify the algos later, if var is listed as variable, we need to loop over it.
-            self._makeVariableArgAsList(namings, test['variants'])
+            self._makeVariableArgAsList(namings, variants)
 
             # gen
-            result += idefixTestGenerator.genTestConfigs(namings, test['variants'], test.get('when', {}))
+            result += idefixTestGenerator.genTestConfigs(namings, variants, whenClauses=whenClauses, defaultConfig=defaultConfig)
         except Exception as e:
           raise Exception(f"Fail to generate tests from {testfileRelPath} : {e}")
 
@@ -151,7 +158,7 @@ class IdexPytestRunner:
 
     # check produced
     for file in check_file_produced:
-      if not os.path.exists(file):
+      if not os.path.exists(file) and not self.currentTestRunner.fake:
         raise Exception(f"Don't find expected file to be produced by the run : {file} !")
 
   def _runNonRegression(self, dumpname, ini, config_override, tolerance=0, definitionFile="", nonReg=True, nonRegIni=None, standardTest=True, first_run_ini=None,first_run_dumpname=None,configure_and_compile=True):

--- a/pytools/tests/test/pb1/testme.json
+++ b/pytools/tests/test/pb1/testme.json
@@ -1,11 +1,13 @@
 {
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "tolerance": 1e-14
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
-      "ini": ["idefix.ini","idefix-implicit.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "tolerance": 1e-14
+      "ini": ["idefix.ini","idefix-implicit.ini"]
     }
   ]
 }

--- a/pytools/tests/test/pb2/testme.json
+++ b/pytools/tests/test/pb2/testme.json
@@ -1,18 +1,18 @@
 {
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "reconstruction": 2,
+    "tolerance": 1e-14
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
       "ini": ["idefix.ini","idefix-implicit.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "tolerance": 1e-14
+      "noplot": true
     },
     {
       "dumpname": "dump.0001.dmp",
       "ini": ["idefix.ini","idefix-implicit.ini"],
-      "noplot": false,
-      "reconstruction": 2,
-      "tolerance": 1e-14
+      "noplot": false
     }
   ]
 }

--- a/test/Dust/DustEnergy/testme.json
+++ b/test/Dust/DustEnergy/testme.json
@@ -1,12 +1,14 @@
 {
   "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "tolerance": 0
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
-      "ini": ["idefix.ini","idefix-implicit.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "tolerance": 0
+      "ini": ["idefix.ini","idefix-implicit.ini"]
     }
   ]
 }

--- a/test/Dust/DustyShock/testme.json
+++ b/test/Dust/DustyShock/testme.json
@@ -1,11 +1,13 @@
 {
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "tolerance": 1e-14
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
-      "ini": ["idefix.ini","idefix-implicit.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "tolerance": 1e-14
+      "ini": ["idefix.ini","idefix-implicit.ini"]
     }
   ]
 }

--- a/test/Dust/DustyWave/testme.json
+++ b/test/Dust/DustyWave/testme.json
@@ -1,12 +1,14 @@
 {
   "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "tolerance": 1e-14
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
-      "ini": ["idefix.ini","idefix-implicit.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "tolerance": 1e-14
+      "ini": ["idefix.ini","idefix-implicit.ini"]
     }
   ]
 }

--- a/test/HD/FargoPlanet/testme.json
+++ b/test/HD/FargoPlanet/testme.json
@@ -1,15 +1,17 @@
 {
   "namings": "ini,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "single": false,
+    "dec": [2, 2],
+    "tolerance": 1e-13
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
       "ini": ["idefix.ini", "idefix-rkl.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "single": false,
-      "mpi": [false, true],
-      "dec": [2, 2],
-      "tolerance": 1e-13
+      "mpi": [false, true]
     }
   ],
   "when": [

--- a/test/HD/MachReflection/testme.json
+++ b/test/HD/MachReflection/testme.json
@@ -1,15 +1,17 @@
 {
   "namings": "ini,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "single": false,
+    "dec": [2, 2],
+    "tolerance": 0
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
       "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
-      "noplot": true,
-      "reconstruction": 2,
-      "single": false,
-      "mpi": [false, true],
-      "dec": [2, 2],
-      "tolerance": 0
+      "mpi": [false, true]
     }
   ]
 }

--- a/test/HD/SedovBlastWave/testme.json
+++ b/test/HD/SedovBlastWave/testme.json
@@ -8,6 +8,7 @@
     "mpi": true,
     "dec": [2, 2, 2 ],
     "standardTest": false,
+    "nonRegressionTest": false,
     "tolerance": 0
   },
   "variants": [

--- a/test/HD/SedovBlastWave/testme.json
+++ b/test/HD/SedovBlastWave/testme.json
@@ -1,28 +1,22 @@
 {
   "namings": "definitionFile,ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "vectPot": false,
+    "reconstruction": 2,
+    "single": false,
+    "mpi": true,
+    "dec": [2, 2, 2 ],
+    "standardTest": false,
+    "tolerance": 0
+  },
   "variants": [
     {
-      "dumpname": "dump.0001.dmp",
       "definitionFile": "definitions.hpp",
-      "ini": ["idefix.ini"],
-      "vectPot": false,
-      "reconstruction": 2,
-      "single": false,
-      "mpi": true,
-      "dec": [2, 2, 2 ],
-      "standardTest": false,
-      "tolerance": 0
+      "ini": ["idefix.ini"]
     },{
-      "dumpname": "dump.0001.dmp",
       "definitionFile": "definitions-spherical.hpp",
-      "ini": ["idefix-spherical.ini"],
-      "vectPot": false,
-      "reconstruction": 2,
-      "single": false,
-      "mpi": true,
-      "dec": [2, 2, 2 ],
-      "standardTest": false,
-      "tolerance": 0
+      "ini": ["idefix-spherical.ini"]
     }
   ]
 }

--- a/test/HD/ShearingBox/testme.json
+++ b/test/HD/ShearingBox/testme.json
@@ -1,15 +1,17 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-fargo.ini"],
-            "noplot": true,
-            "reconstruction": 2,
-            "single": false,
-            "mpi": false,
-            "dec": ["2","1","2"],
-            "tolerance": 1e-15
-        }
-    ]
+  "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "single": false,
+    "mpi": false,
+    "dec": ["2","1","2"],
+    "tolerance": 1e-15
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-fargo.ini"]
+    }
+  ]
 }

--- a/test/HD/ViscousDisk/testme.json
+++ b/test/HD/ViscousDisk/testme.json
@@ -1,15 +1,17 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "reconstruction": 2,
-            "single": false,
-            "mpi": false,
-            "dec": ["2","1","2"],
-            "tolerance": 3e-15
-        }
-    ]
+  "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "single": false,
+    "mpi": false,
+    "dec": ["2","1","2"],
+    "tolerance": 3e-15
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini"]
+    }
+  ]
 }

--- a/test/HD/ViscousFlowPastCylinder/testme.json
+++ b/test/HD/ViscousFlowPastCylinder/testme.json
@@ -1,23 +1,25 @@
 {
-    "namings": "ini,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "reconstruction": 2,
-            "single": false,
-            "mpi": [false, true],
-            "dec": ["2","2"],
-            "tolerance": 3e-14
-        }
-    ],
-    "when": {
-        "conditions": {
-            "ini": "idefix-rkl.ini"
-        },
-        "apply": {
-            "tolerance": 1e-8
-        }
+  "namings": "ini,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "single": false,
+    "dec": ["2","2"],
+    "tolerance": 3e-14
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini"],
+      "mpi": [false, true]
     }
+  ],
+  "when": {
+    "conditions": {
+      "ini": "idefix-rkl.ini"
+    },
+    "apply": {
+      "tolerance": 1e-8
+    }
+  }
 }

--- a/test/HD/sod-iso/testme.json
+++ b/test/HD/sod-iso/testme.json
@@ -1,33 +1,25 @@
 {
-    "namings": "ini,single,reconstruction",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
-            "vectPot": false,
-            "noplot": true,
-            "reconstruction": [2, 3],
-            "single": [false],
-            "mpi": false,
-            "tolerance": 0
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix-rk3.ini","idefix-hllc-rk3.ini"],
-            "vectPot": false,
-            "noplot": true,
-            "reconstruction": [4],
-            "single": [false],
-            "mpi": false,
-            "tolerance": 0
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
-            "vectPot": false,
-            "noplot": true,
-            "reconstruction": [2],
-            "single": [true],
-            "mpi": false,
-            "tolerance": 0
-        }
-    ]
+  "namings": "ini,single,reconstruction",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "mpi": false,
+    "vectPot": false,
+    "noplot": true,
+    "tolerance": 0
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
+      "reconstruction": [2, 3],
+      "single": [false]
+    },{
+      "ini": ["idefix-rk3.ini","idefix-hllc-rk3.ini"],
+      "reconstruction": [4],
+      "single": [false]
+    },{
+      "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
+      "reconstruction": [2],
+      "single": [true]
+    }
+  ]
 }

--- a/test/HD/sod/testme.json
+++ b/test/HD/sod/testme.json
@@ -1,33 +1,25 @@
 {
-    "namings": "ini,single,reconstruction",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": [false],
-            "reconstruction": [2,3],
-            "mpi": false,
-            "tolerance": 0
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix-rk3.ini","idefix-hllc-rk3.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": [false],
-            "reconstruction": [4],
-            "mpi": false,
-            "tolerance": 0
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "reconstruction": [2],
-            "mpi": false,
-            "single": [true],
-            "tolerance": 0
-        }
-    ]
+  "namings": "ini,single,reconstruction",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "mpi": false,
+    "noplot": true,
+    "vectPot": false,
+    "tolerance": 0
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
+      "single": [false],
+      "reconstruction": [2,3]
+    },{
+      "ini": ["idefix-rk3.ini","idefix-hllc-rk3.ini"],
+      "single": [false],
+      "reconstruction": [4]
+    },{
+      "ini": ["idefix.ini","idefix-hll.ini","idefix-hllc.ini","idefix-tvdlf.ini"],
+      "reconstruction": [2],
+      "single": [true]
+    }
+  ]
 }

--- a/test/HD/thermalDiffusion/testme.json
+++ b/test/HD/thermalDiffusion/testme.json
@@ -1,15 +1,17 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "reconstruction": 2,
-            "single": false,
-            "mpi": false,
-            "dec": ["2","1","2"],
-            "tolerance": 0
-        }
-    ]
+  "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "reconstruction": 2,
+    "single": false,
+    "mpi": false,
+    "dec": ["2","1","2"],
+    "tolerance": 0
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini"]
+    }
+  ]
 }

--- a/test/IO/dump/testme.json
+++ b/test/IO/dump/testme.json
@@ -1,28 +1,23 @@
 {
-    "namings": "ini,single,vectPot,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "vectPot": [false, true],
-            "reconstruction": 2,
-            "single": [false],
-            "mpi": [false, true],
-            "dec": ["2","2","2"],
-            "standardTest": false,
-            "nonRegressionTest": false,
-            "tolerance": 1e-13
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "vectPot": [false],
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "single": [true],
-            "dec": ["2","2","2"],
-            "standardTest": false,
-            "nonRegressionTest": false,
-            "tolerance": 1e-13
-        }
-    ]
+  "default": {
+      "ini": "idefix.ini",
+      "dumpname": "dump.0001.dmp",
+      "tolerance": 1e-13,
+      "nonRegressionTest": false,
+      "standardTest": false,
+      "reconstruction": 2,
+      "dec": [2, 2, 2]
+  },
+  "variants": [
+    {
+      "single": false,
+      "vectPot": [false, true],
+      "mpi": [false, true]
+    }, {
+
+      "vectPot": false,
+      "single": true,
+      "mpi": [false, true]
+    }
+  ]
 }

--- a/test/IO/pydefix/testme.json
+++ b/test/IO/pydefix/testme.json
@@ -1,17 +1,17 @@
 {
-    "namings": "ini,single,vectPot,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "reconstruction": 2,
-            "single": false,
-            "mpi": [false, true],
-            "dec": ["2","2"],
-            "standardTest": false,
-            "tolerance": 1e-12
-        }
-    ]
+  "default": {
+    "ini": "idefix.ini",
+      "dumpname": "dump.0001.dmp",
+      "tolerance": 1e-12,
+      "dec": [2, 2],
+      "noplot": true,
+      "vectPot": false,
+      "single": false,
+      "reconstruction": 2
+  },
+  "variants": [
+    {
+      "mpi": [false, true]
+    }
+  ]
 }

--- a/test/IO/xdmf/testme.json
+++ b/test/IO/xdmf/testme.json
@@ -1,17 +1,12 @@
 {
-    "namings": "ini,single,vectPot,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "vectPot": false,
-            "reconstruction": 2,
-            "single": false,
-            "mpi": false,
-            "dec": ["2","2","2"],
-            "standardTest": false,
-            "nonRegressionTest": false,
-            "check_file_produced": [ "data.0001.flt.xmf", "data.0001.flt.h5" ]
-        }
-    ]
+  "default": {
+    "ini": "idefix.ini",
+    "dumpname": "dump.0001.dmp",
+    "vectPot": false,
+    "single": false,
+    "mpi": false,
+    "nonRegressionTest": false,
+    "standardTest": false,
+    "check_file_produced": [ "data.0001.flt.xmf", "data.0001.flt.h5" ]
+  }
 }

--- a/test/MHD/AmbipolarCshock/testme.json
+++ b/test/MHD/AmbipolarCshock/testme.json
@@ -1,14 +1,16 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "tolerance": 0
-        }
-    ]
+  "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "single": false,
+    "reconstruction": 2,
+    "mpi": false,
+    "tolerance": 0
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini"]
+    }
+  ]
 }

--- a/test/MHD/AmbipolarCshock3D/testme.json
+++ b/test/MHD/AmbipolarCshock3D/testme.json
@@ -1,35 +1,33 @@
 {
-    "namings": "ini,mpi,vectPot",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false],
-            "vectPot": [false, true],
-            "dec": ["2","1","1"],
-            "tolerance": 3e-14
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [true],
-            "vectPot": [false],
-            "dec": ["2","1","1"],
-            "tolerance": 3e-14
-        }
-    ],
-    "when": {
-        "conditions": {
-            "ini": "idefix-rkl.ini",
-            "mpi": true
-        },
-        "apply": {
-            "tolerance": 2e-10
-        }
+  "namings": "ini,mpi,vectPot",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "single": false,
+    "reconstruction": 2,
+    "tolerance": 3e-14
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini"],
+      "mpi": [false],
+      "vectPot": [false, true],
+      "dec": ["2","1","1"]
+    },{
+      "ini": ["idefix.ini","idefix-rkl.ini"],
+      "mpi": [true],
+      "vectPot": [false],
+      "dec": ["2","1","1"],
+      "tolerance": 3e-14
     }
+  ],
+  "when": {
+    "conditions": {
+      "ini": "idefix-rkl.ini",
+      "mpi": true
+    },
+    "apply": {
+      "tolerance": 2e-10
+    }
+  }
 }

--- a/test/MHD/AxisFluxTube/testme.json
+++ b/test/MHD/AxisFluxTube/testme.json
@@ -1,16 +1,18 @@
 {
-    "namings": "ini,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-coarsening.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "vectPot": false,
-            "standardTest": false,
-            "tolerance": 1e-14
-        }
-    ]
+  "namings": "ini,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "single": false,
+    "reconstruction": 2,
+    "vectPot": false,
+    "standardTest": false,
+    "tolerance": 1e-14
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-coarsening.ini"],
+      "mpi": [false, true]
+    }
+  ]
 }

--- a/test/MHD/Coarsening/testme.json
+++ b/test/MHD/Coarsening/testme.json
@@ -1,12 +1,14 @@
 {
-    "namings": "ini,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini","idefix-x2.ini","idefix-x3.ini"],
-            "noplot": true,
-            "mpi": [false,true],
-            "tolerance": 0
-        }
-    ]
+  "namings": "ini,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "tolerance": 0
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini","idefix-x2.ini","idefix-x3.ini"],
+      "mpi": [false,true]
+    }
+  ]
 }

--- a/test/MHD/FargoMHDSpherical/testme.json
+++ b/test/MHD/FargoMHDSpherical/testme.json
@@ -1,17 +1,19 @@
 {
-    "namings": "ini,mpi,vectPot",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "vectPot": [false, true],
-            "mpi": [false, true],
-            "dec": ["2","2","2"],
-            "standardTest": false,
-            "tolerance": 1e-14
-        }
-    ]
+  "namings": "ini,mpi,vectPot",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "single": false,
+    "reconstruction": 2,
+    "dec": ["2","2","2"],
+    "standardTest": false,
+    "tolerance": 1e-14
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini"],
+      "vectPot": [false, true],
+      "mpi": [false, true]
+    }
+  ]
 }

--- a/test/MHD/HallWhistler/testme.json
+++ b/test/MHD/HallWhistler/testme.json
@@ -1,15 +1,12 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "tolerance": 1e-15
-        }
-    ]
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "ini": "idefix.ini",
+    "noplot": true,
+    "vectPot": false,
+    "single": false,
+    "reconstruction": 2,
+    "mpi": false,
+    "tolerance": 1e-15
+  }
 }

--- a/test/MHD/LinearWaveTest/testme.json
+++ b/test/MHD/LinearWaveTest/testme.json
@@ -1,24 +1,22 @@
 {
-    "namings": "ini,reconstruction,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix-fast.ini","idefix-slow.ini","idefix-alfven.ini","idefix-entropy.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": [2],
-            "mpi": [false,true],
-            "dec": ["2","2","2"],
-            "tolerance": 2e-13
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix-fast.ini","idefix-slow.ini","idefix-alfven.ini","idefix-entropy.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": [3, 4],
-            "mpi": [false],
-            "dec": ["2","2","2"],
-            "tolerance": 2e-13
-        }
-    ]
+  "namings": "ini,reconstruction,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "dec": ["2","2","2"],
+    "tolerance": 2e-13
+  },
+  "variants": [
+    {
+      "ini": ["idefix-fast.ini","idefix-slow.ini","idefix-alfven.ini","idefix-entropy.ini"],
+      "single": false,
+      "reconstruction": [2],
+      "mpi": [false,true]
+    },{
+      "ini": ["idefix-fast.ini","idefix-slow.ini","idefix-alfven.ini","idefix-entropy.ini"],
+      "single": false,
+      "reconstruction": [3, 4],
+      "mpi": [false]
+    }
+  ]
 }

--- a/test/MHD/MTI/testme.json
+++ b/test/MHD/MTI/testme.json
@@ -1,15 +1,17 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-rkl.ini","idefix-sl.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "tolerance": 0
-        }
-    ]
+  "namings": "ini",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "vectPot": false,
+    "single": false,
+    "reconstruction": 2,
+    "mpi": false,
+    "tolerance": 0
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini","idefix-rkl.ini","idefix-sl.ini"]
+    }
+  ]
 }

--- a/test/MHD/OrszagTang/testme.json
+++ b/test/MHD/OrszagTang/testme.json
@@ -1,74 +1,66 @@
 {
-    "namings": "ini,reconstruction,mpi,single,vectPot",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": [
-                "idefix.ini",
-                "idefix-hll.ini",
-                "idefix-hlld-arithmetic.ini",
-                "idefix-hlld-hll.ini",
-                "idefix-hlld-hlld.ini",
-                "idefix-hlld-uct0.ini",
-                "idefix-hlld.ini",
-                "idefix-tvdlf.ini"
-            ],
-            "noplot": true,
-            "vectPot": [false],
-            "single": false,
-            "reconstruction": [2,3,4],
-            "mpi": [false, true],
-            "dec": ["2","2"],
-            "tolerance": 1e-12,
-            "standardTest": false
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": [
-                "idefix.ini",
-                "idefix-hll.ini",
-                "idefix-hlld-arithmetic.ini",
-                "idefix-hlld-hll.ini",
-                "idefix-hlld-hlld.ini",
-                "idefix-hlld-uct0.ini",
-                "idefix-hlld.ini",
-                "idefix-tvdlf.ini"
-            ],
-            "noplot": true,
-            "vectPot": [false],
-            "single": true,
-            "reconstruction": [2],
-            "mpi": [false],
-            "dec": ["2","2"],
-            "tolerance": 1e-12,
-            "standardTest": false
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": [
-                "idefix.ini",
-                "idefix-hll.ini",
-                "idefix-hlld-arithmetic.ini",
-                "idefix-hlld-hll.ini",
-                "idefix-hlld-hlld.ini",
-                "idefix-hlld-uct0.ini",
-                "idefix-hlld.ini",
-                "idefix-tvdlf.ini"
-            ],
-             "noplot": true,
-            "vectPot": [true],
-            "single": false,
-            "reconstruction": [2],
-            "mpi": [false],
-            "dec": ["2","2"],
-            "tolerance": 1e-12,
-            "standardTest": false
-        }
-    ],
-    "when": {
-        "conditions": {
-            "single": true
-        },
-        "apply" : {
-            "tolerance": 1e-5
-        }
+  "namings": "ini,reconstruction,mpi,single,vectPot",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "dec": ["2","2"],
+    "tolerance": 1e-12,
+    "standardTest": false
+  },
+  "variants": [
+    {
+      "ini": [
+        "idefix.ini",
+        "idefix-hll.ini",
+        "idefix-hlld-arithmetic.ini",
+        "idefix-hlld-hll.ini",
+        "idefix-hlld-hlld.ini",
+        "idefix-hlld-uct0.ini",
+        "idefix-hlld.ini",
+        "idefix-tvdlf.ini"
+      ],
+      "vectPot": [false],
+      "single": false,
+      "reconstruction": [2,3,4],
+      "mpi": [false, true]
+    },{
+      "ini": [
+        "idefix.ini",
+        "idefix-hll.ini",
+        "idefix-hlld-arithmetic.ini",
+        "idefix-hlld-hll.ini",
+        "idefix-hlld-hlld.ini",
+        "idefix-hlld-uct0.ini",
+        "idefix-hlld.ini",
+        "idefix-tvdlf.ini"
+      ],
+      "vectPot": [false],
+      "single": true,
+      "reconstruction": [2],
+      "mpi": [false]
+    },{
+      "ini": [
+        "idefix.ini",
+        "idefix-hll.ini",
+        "idefix-hlld-arithmetic.ini",
+        "idefix-hlld-hll.ini",
+        "idefix-hlld-hlld.ini",
+        "idefix-hlld-uct0.ini",
+        "idefix-hlld.ini",
+        "idefix-tvdlf.ini"
+      ],
+      "vectPot": [true],
+      "single": false,
+      "reconstruction": [2],
+      "mpi": [false]
     }
+  ],
+  "when": {
+    "conditions": {
+      "single": true
+    },
+    "apply" : {
+      "tolerance": 1e-5
+    }
+  }
 }

--- a/test/MHD/OrszagTang3D/testme.json
+++ b/test/MHD/OrszagTang3D/testme.json
@@ -1,34 +1,31 @@
 {
-    "namings": "ini,single,vectPot,mpi",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "vectPot": [false, true],
-            "reconstruction": 2,
-            "single": [false],
-            "mpi": [false, true],
-            "dec": ["2","2","2"],
-            "standardTest": false,
-            "tolerance": 1e-13
-        },{
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "vectPot": [false],
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "single": [true],
-            "dec": ["2","2","2"],
-            "standardTest": false,
-            "tolerance": 1e-13
-        }
-    ],
-    "when": {
-        "conditions": {
-            "single": true
-        },
-        "apply" : {
-            "tolerance": 1e-6
-        }
+  "namings": "ini,single,vectPot,mpi",
+  "default": {
+    "dumpname": "dump.0001.dmp",
+    "reconstruction": 2,
+    "dec": ["2","2","2"],
+    "standardTest": false,
+    "tolerance": 1e-13
+  },
+  "variants": [
+    {
+      "ini": ["idefix.ini"],
+      "vectPot": [false, true],
+      "single": [false],
+      "mpi": [false, true]
+    },{
+      "ini": ["idefix.ini"],
+      "vectPot": [false],
+      "mpi": [false, true],
+      "single": [true]
     }
+  ],
+  "when": {
+    "conditions": {
+      "single": true
+    },
+    "apply" : {
+      "tolerance": 1e-6
+    }
+  }
 }

--- a/test/MHD/ResistiveAlfvenWave/testme.json
+++ b/test/MHD/ResistiveAlfvenWave/testme.json
@@ -1,14 +1,16 @@
 {
     "namings": "ini,mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "single": false,
+        "reconstruction": 2,
+        "tolerance": 1e-14
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-rkl.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "tolerance": 1e-14
+            "mpi": [false, true]
         }
     ],
     "when": {

--- a/test/MHD/ShearingBox/testme.json
+++ b/test/MHD/ShearingBox/testme.json
@@ -1,15 +1,17 @@
 {
     "namings": "ini,mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2","1","2"],
+        "tolerance": 1e-14
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-fargo.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "dec": ["2","1","2"],
-            "tolerance": 1e-14
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/MHD/clessTDiffusion/testme.json
+++ b/test/MHD/clessTDiffusion/testme.json
@@ -1,15 +1,12 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "vectPot": false,
-            "tolerance": 2e-15
-        }
-    ]
+  "default": {
+    "ini": "idefix.ini",
+    "dumpname": "dump.0001.dmp",
+    "noplot": true,
+    "single": false,
+    "reconstruction": 2,
+    "mpi": false,
+    "vectPot": false,
+    "tolerance": 2e-15
+  }
 }

--- a/test/MHD/sod-iso/testme.json
+++ b/test/MHD/sod-iso/testme.json
@@ -1,33 +1,25 @@
 {
     "namings": "ini,reconstruction,single",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "vectPot": false,
+        "mpi": false,
+        "standardTest": false,
+        "tolerance": 0
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-hll.ini","idefix-hlld.ini","idefix-tvdlf.ini"],
-            "vectPot": false,
             "single": false,
-            "reconstruction": [2,3],
-            "mpi": false,
-            "standardTest": false,
-            "tolerance": 0
+            "reconstruction": [2,3]
         },{
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix-rk3.ini","idefix-hlld-rk3.ini"],
-            "vectPot": false,
             "single": false,
-            "reconstruction": [4],
-            "mpi": false,
-            "standardTest": false,
-            "tolerance": 0
+            "reconstruction": [4]
         },{
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-hll.ini","idefix-hlld.ini","idefix-tvdlf.ini"],
-            "vectPot": false,
             "reconstruction": [2],
-            "mpi": false,
-            "single": true,
-            "standardTest": false,
-            "tolerance": 0
+            "single": true
         }
     ],
     "when": [

--- a/test/MHD/sod/testme.json
+++ b/test/MHD/sod/testme.json
@@ -1,33 +1,28 @@
 {
     "namings": "ini,reconstruction,single",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "vectPot": false,
+        "mpi": false,
+        "standardTest": false,
+        "tolerance": 0
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-hll.ini","idefix-hlld.ini","idefix-tvdlf.ini"],
-            "vectPot": false,
             "single": false,
             "reconstruction": [2,3],
-            "mpi": false,
-            "standardTest": false,
-            "tolerance": 0
+            "standardTest": false
         },{
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix-rk3.ini","idefix-hlld-rk3.ini"],
-            "vectPot": false,
             "single": false,
             "reconstruction": 4,
-            "mpi": false,
             "standardTest": false,
             "tolerance": 0
         },{
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-hll.ini","idefix-hlld.ini","idefix-tvdlf.ini"],
-            "vectPot": false,
             "reconstruction": 2,
-            "mpi": false,
-            "single": true,
-            "standardTest": false,
-            "tolerance": 0
+            "single": true
         }
     ]
 }

--- a/test/MHD/sphBragTDiffusion/testme.json
+++ b/test/MHD/sphBragTDiffusion/testme.json
@@ -1,15 +1,12 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "tolerance": 2e-15
-        }
-    ]
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "mpi": false,
+        "tolerance": 2e-15
+    }
 }

--- a/test/MHD/sphBragViscosity/testme.json
+++ b/test/MHD/sphBragViscosity/testme.json
@@ -1,16 +1,13 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "standardTest": false,
-            "tolerance": 1e-15
-        }
-    ]
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "mpi": false,
+        "standardTest": false,
+        "tolerance": 1e-15
+    }
 }

--- a/test/Planet/PlanetMigration2D/testme.json
+++ b/test/Planet/PlanetMigration2D/testme.json
@@ -1,16 +1,18 @@
 {
-    "namings": "ini,mpi",
+    "namings": "mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2","2"],
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "dec": ["2","2"],
-            "tolerance": 1e-13
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/Planet/PlanetPlanetRK42D/testme.json
+++ b/test/Planet/PlanetPlanetRK42D/testme.json
@@ -1,16 +1,18 @@
 {
-    "namings": "ini,mpi",
+    "namings": "mpi",
+    "default": {
+        "ini": "idefix.ini",
+        "dumpname": "dump.0002.dmp",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2","2"],
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0002.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
             "mpi": [false, true],
-            "dec": ["2","2"],
-            "tolerance": 1e-13,
             "multirun": [
                 {
                     "nonRegressionTest": true,

--- a/test/Planet/PlanetSpiral2D/testme.json
+++ b/test/Planet/PlanetSpiral2D/testme.json
@@ -1,16 +1,18 @@
 {
-    "namings": "ini,mpi",
+    "namings": "mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2","2"],
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "dec": ["2","2"],
-            "tolerance": 1e-13
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/Planet/PlanetTorque3D/testme.json
+++ b/test/Planet/PlanetTorque3D/testme.json
@@ -1,16 +1,18 @@
 {
     "namings": "ini,mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2","2","2"],
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "dec": ["2","2","2"],
-            "tolerance": 1e-13
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/Planet/PlanetsIsActiveRK52D/testme.json
+++ b/test/Planet/PlanetsIsActiveRK52D/testme.json
@@ -1,17 +1,19 @@
 {
     "namings": "ini,mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2","2"],
+        "nonRegressionTest": false,
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix-rk4.ini", "idefix-rk5.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "dec": ["2","2"],
-            "nonRegressionTest": false,
-            "tolerance": 1e-13
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/SelfGravity/DustyCollapse/testme.json
+++ b/test/SelfGravity/DustyCollapse/testme.json
@@ -1,16 +1,18 @@
 {
-    "namings": "ini,mpi",
+    "namings": "mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "nonRegressionTest": false,
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "nonRegressionTest": false,
-            "tolerance": 1e-13
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/SelfGravity/JeansInstability/testme.json
+++ b/test/SelfGravity/JeansInstability/testme.json
@@ -1,17 +1,19 @@
 {
     "namings": "ini,mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "vectPot": false,
+        "single": false,
+        "reconstruction": 2,
+        "dec": ["2"],
+        "nonRegressionTest": false,
+        "tolerance": 1e-13
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-cg.ini"],
-            "noplot": true,
-            "vectPot": false,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": [false, true],
-            "dec": ["2"],
-            "nonRegressionTest": false,
-            "tolerance": 1e-13
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/SelfGravity/RandomSphere/testme.json
+++ b/test/SelfGravity/RandomSphere/testme.json
@@ -1,14 +1,16 @@
 {
     "namings": "ini,mpi",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "dec": ["2","2","1"],
+        "nonRegressionTest": false,
+        "tolerance": 0
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
             "ini": ["idefix.ini","idefix-cg.ini","idefix-minres.ini"],
-            "noplot": true,
-            "mpi": [false, true],
-            "dec": ["2","2","1"],
-            "nonRegressionTest": false,
-            "tolerance": 0
+            "mpi": [false, true]
         }
     ]
 }

--- a/test/SelfGravity/RandomSphereCartesian/testme.json
+++ b/test/SelfGravity/RandomSphereCartesian/testme.json
@@ -1,12 +1,14 @@
 {
     "namings": "ini",
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "noplot": true,
+        "nonRegressionTest": false,
+        "tolerance": 0
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini","idefix-cg.ini","idefix-minres.ini","idefix-jacobi.ini"],
-            "noplot": true,
-            "nonRegressionTest": false,
-            "tolerance": 0
+            "ini": ["idefix.ini","idefix-cg.ini","idefix-minres.ini","idefix-jacobi.ini"]
         }
     ]
 }

--- a/test/SelfGravity/UniformCollapse/testme.json
+++ b/test/SelfGravity/UniformCollapse/testme.json
@@ -1,16 +1,13 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "noplot": true,
-            "single": false,
-            "reconstruction": 2,
-            "mpi": false,
-            "standardTest": false,
-            "tolerance": 0,
-            "nonRegressionTest": false
-        }
-    ]
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "noplot": true,
+        "single": false,
+        "reconstruction": 2,
+        "mpi": false,
+        "standardTest": false,
+        "tolerance": 0,
+        "nonRegressionTest": false
+    }
 }

--- a/test/utils/columnDensity/testme.json
+++ b/test/utils/columnDensity/testme.json
@@ -1,13 +1,15 @@
 {
-    "namings": "ini,mpi",
+    "namings": "mpi",
+    "default": {
+        "ini": "idefix.ini",
+        "dumpname": "dump.0001.dmp",
+        "nonRegressionTest": false,
+        "standardTest": false,
+        "tolerance": 0
+    },
     "variants": [
         {
-            "dumpname": "dump.0001.dmp",
-            "ini": ["idefix.ini"],
-            "mpi": [false,true],
-            "nonRegressionTest": false,
-            "standardTest": false,
-            "tolerance": 0
+            "mpi": [false,true]
         }
     ]
 }

--- a/test/utils/lookupTable/testme.json
+++ b/test/utils/lookupTable/testme.json
@@ -1,12 +1,9 @@
 {
-    "namings": "ini",
-    "variants": [
-        {
-            "dumpname": "dump.0001.dmp",
-            "ini":["idefix.ini"],
-            "nonRegressionTest": false,
-            "standardTest": false,
-            "tolerance": 0
-        }
-    ]
+    "default": {
+        "dumpname": "dump.0001.dmp",
+        "ini": "idefix.ini",
+        "nonRegressionTest": false,
+        "standardTest": false,
+        "tolerance": 0
+    }
 }


### PR DESCRIPTION
What
--------

Adds the `default` semantic in the `testme.json`.

It will be usefull latter to also re-generate the reference data via the new pytest runner by knowing with which sets of parameter to run it (require a small extra work).

In addition it makes the `testme.json more readable on what is fixed and what vary.

Example
------------

The testme.json now looks like : 

```json
{
  "default": {
    "dumpname": "dump.0001.dmp",
    "reconstruction": 2,
    "tolerance": 1e-14
  },
  "variants": {
     "mpi": [false, true],
     "single": [false, true],
  }
}
```

Doc
-----

The documentation has been updated.
