### PR TITLE
Move pytest configuration out of an "ini" file, separate inifiles validation from formatting 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,9 @@ repos:
   - repo: https://github.com/neutrinoceros/inifix
     rev: v6.1.2
     hooks:
+      - id: inifix-validate
       - id: inifix-format
+        args: ["--skip-validation"]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,0 +1,10 @@
+[pytest]
+minversion = "9.0"
+markers = [
+  "default: Test to run by default.",
+]
+python_files = [
+  "test_*.py",
+]
+junit_logging = "system-out"
+junit_log_passing_tests = false


### PR DESCRIPTION
Motivation:
keeping the default filename regexp for inifix pre-commit hooks makes it easier for me to continuously verify that I'm not breaking idefix's linting.
In short: this moves back to the `.ini` extension being unambiguously about idefix/pluto configuration files.

- **move pytest config to pytest.toml**
- **separate inifiles validation from formatting**
