### PR TITLE
Move pytest configuration out of an "ini" file, separate inifiles validation from formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,10 @@ repos:
   - repo: https://github.com/neutrinoceros/inifix
     rev: v6.1.2
     hooks:
+      - id: inifix-validate
+        args: [--sections=require]
       - id: inifix-format
-        files: ^(test/).*\.(ini)$ # want to skip pytest.ini
+        args: [--skip-validation]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-markers=
-  default: Test to run by default.
-python_files="test_*.py"
-junit_logging="system-out"
-junit_log_passing_tests=false

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,0 +1,10 @@
+[pytest]
+minversion = "9.0"
+markers = [
+  "default: Test to run by default.",
+]
+python_files = [
+  "test_*.py",
+]
+junit_logging = "system-out"
+junit_log_passing_tests = false

--- a/pytools/pytest.ini
+++ b/pytools/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files="test_*.py"

--- a/test/python_requirements.txt
+++ b/test/python_requirements.txt
@@ -9,6 +9,5 @@ scipy>=1.2.3
 # note that no version of inifix supports Python older than 3.6
 inifix>=0.11.2
 
-# To run the test suite, we can use pytest, mostly any version
-# 6.0 is the one available on system available on debian-11
-pytest >= 6.0
+# To run the test suite, we can use pytest
+pytest>=9.0


### PR DESCRIPTION
Motivation:
keeping the default filename regexp for inifix pre-commit hooks makes it easier for me to continuously verify that I'm not breaking idefix's linting.
In short: this moves back to the `.ini` extension being unambiguously about idefix/pluto configuration files.

- **move pytest config to pytest.toml**
- **separate inifiles validation from formatting**

supersedes #379