### PR TITLE
fix: remaining issues in the test suite following the upgrade to kokkos-5.1

### DIFF
--- a/.github/workflows/actions/pre-install-py-packages/action.yml
+++ b/.github/workflows/actions/pre-install-py-packages/action.yml
@@ -1,0 +1,15 @@
+name: Install python packages
+
+description: "Action installing the Idefix python packages before running the tests."
+
+inputs: {}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create venv
+      shell: bash
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        python3 -m pip install -r ./test/python_requirements.txt

--- a/.github/workflows/idefix-ci-jobs.yml
+++ b/.github/workflows/idefix-ci-jobs.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Sod test
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/sod -all $TESTME_OPTIONS
       - name: Isothermal Sod test
@@ -46,6 +48,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Viscous flow past cylinder
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/ViscousFlowPastCylinder -all $TESTME_OPTIONS
       - name: Viscous disk
@@ -60,6 +64,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: MHD Sod test
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/sod -all $TESTME_OPTIONS
       - name: MHD Isothermal Sod test
@@ -80,6 +86,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Ambipolar C Shock
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/AmbipolarCshock -all $TESTME_OPTIONS
       - name: Ambipolar C Shock 3D
@@ -99,6 +107,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Fargo + planet
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/FargoPlanet -all $TESTME_OPTIONS
       - name: Fargo MHD spherical
@@ -112,6 +122,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Hydro shearing box
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/ShearingBox -all $TESTME_OPTIONS
       - name: MHD shearing box
@@ -125,6 +137,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Jeans Instability
         run: scripts/ci/run-tests $IDEFIX_DIR/test/SelfGravity/JeansInstability -all $TESTME_OPTIONS
       - name: Random sphere spherical
@@ -144,6 +158,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: 3 body
         run: scripts/ci/run-tests $IDEFIX_DIR/test/Planet/Planet3Body -all $TESTME_OPTIONS
       - name: migration
@@ -165,6 +181,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Energy conservation
         run: scripts/ci/run-tests $IDEFIX_DIR/test/Dust/DustEnergy -all $TESTME_OPTIONS
       - name: Dusty wave
@@ -178,6 +196,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: MTI
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/MTI -all $TESTME_OPTIONS
       - name: Spherical anisotropic diffusion
@@ -195,6 +215,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Run examples test
         run: cd test && ./checks_examples.sh $TEST_OPTIONS
 
@@ -206,6 +228,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Lookup table
         run: scripts/ci/run-tests $IDEFIX_DIR/test/utils/lookupTable -all $TESTME_OPTIONS
       - name: Dump Image
@@ -221,6 +245,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Prep python
+        uses: ./actions/pre-install-py-packages
       - name: Restart dumps
         run: scripts/ci/run-tests $IDEFIX_DIR/test/IO/dump -all $TESTME_OPTIONS
       - name: Pydefix

--- a/.github/workflows/idefix-ci-jobs.yml
+++ b/.github/workflows/idefix-ci-jobs.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Sod test
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/sod -all $TESTME_OPTIONS
       - name: Isothermal Sod test
@@ -49,7 +49,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Viscous flow past cylinder
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/ViscousFlowPastCylinder -all $TESTME_OPTIONS
       - name: Viscous disk
@@ -65,7 +65,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: MHD Sod test
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/sod -all $TESTME_OPTIONS
       - name: MHD Isothermal Sod test
@@ -87,7 +87,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Ambipolar C Shock
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/AmbipolarCshock -all $TESTME_OPTIONS
       - name: Ambipolar C Shock 3D
@@ -108,7 +108,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Fargo + planet
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/FargoPlanet -all $TESTME_OPTIONS
       - name: Fargo MHD spherical
@@ -123,7 +123,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Hydro shearing box
         run: scripts/ci/run-tests $IDEFIX_DIR/test/HD/ShearingBox -all $TESTME_OPTIONS
       - name: MHD shearing box
@@ -138,7 +138,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Jeans Instability
         run: scripts/ci/run-tests $IDEFIX_DIR/test/SelfGravity/JeansInstability -all $TESTME_OPTIONS
       - name: Random sphere spherical
@@ -159,7 +159,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: 3 body
         run: scripts/ci/run-tests $IDEFIX_DIR/test/Planet/Planet3Body -all $TESTME_OPTIONS
       - name: migration
@@ -182,7 +182,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Energy conservation
         run: scripts/ci/run-tests $IDEFIX_DIR/test/Dust/DustEnergy -all $TESTME_OPTIONS
       - name: Dusty wave
@@ -197,7 +197,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: MTI
         run: scripts/ci/run-tests $IDEFIX_DIR/test/MHD/MTI -all $TESTME_OPTIONS
       - name: Spherical anisotropic diffusion
@@ -216,7 +216,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Run examples test
         run: cd test && ./checks_examples.sh $TEST_OPTIONS
 
@@ -229,7 +229,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Lookup table
         run: scripts/ci/run-tests $IDEFIX_DIR/test/utils/lookupTable -all $TESTME_OPTIONS
       - name: Dump Image
@@ -246,7 +246,7 @@ jobs:
         with:
           submodules: recursive
       - name: Prep python
-        uses: ./actions/pre-install-py-packages
+        uses: ./.github/workflows/actions/pre-install-py-packages
       - name: Restart dumps
         run: scripts/ci/run-tests $IDEFIX_DIR/test/IO/dump -all $TESTME_OPTIONS
       - name: Pydefix

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
+
+# load ICC compiler env
 if [ "$IDEFIX_COMPILER" == icc ]; then
     source /opt/intel/oneapi/setvars.sh
 fi
+
+# enable bash features
 set -ue
+
+# load python venv if present
+if [ -d .venv ]; then
+    source .venv/bin/activate
+fi
+
+# jump in test directory
 cd "$1"
+
+# run the test
 ./testme.py "${@:2}"

--- a/src/dataBlock/planetarySystem/planetStructs.hpp
+++ b/src/dataBlock/planetarySystem/planetStructs.hpp
@@ -19,7 +19,7 @@ struct Force {
     real f_ex_inner[3];
     real f_outer[3];
     real f_ex_outer[3];
-    KOKKOS_FUNCTION void operator+=(Force const volatile& f) volatile {
+    KOKKOS_FUNCTION void operator+=(const Force & f) {
         for (int i = 0; i < 3; ++i) {
             f_inner[i] += f.f_inner[i];
             f_ex_inner[i] += f.f_ex_inner[i];

--- a/test/MHD/AmbipolarWind/setup.cpp
+++ b/test/MHD/AmbipolarWind/setup.cpp
@@ -373,7 +373,7 @@ void ComputeUserVars(DataBlock & data, UserDefVariablesContainer &variables) {
   IdefixHostArray1D<real> x1=d.x[IDIR];
   IdefixHostArray1D<real> x2=d.x[JDIR];
   IdefixHostArray4D<real> Vc=d.Vc;
-  IdefixArray3D<real>::HostMirror scrhHost = Kokkos::create_mirror_view(scrh);
+  IdefixArray3D<real>::host_mirror_type scrhHost = Kokkos::create_mirror_view(scrh);
   Kokkos::deep_copy(scrhHost,scrh);
 
   for(int k = d.beg[KDIR]; k < d.end[KDIR] ; k++) {

--- a/test/python_requirements.txt
+++ b/test/python_requirements.txt
@@ -8,3 +8,6 @@ scipy>=1.2.3
 
 # note that no version of inifix supports Python older than 3.6
 inifix>=0.11.2
+
+# It supports Python 3.8 as minimum.
+pybind11 >= 3.0.4

--- a/test/skeleton/main.cpp
+++ b/test/skeleton/main.cpp
@@ -37,7 +37,7 @@ void testReduction() {
 
   // Init an array on device, and image on host
   IdefixArray3D<real> rho = IdefixArray3D<real>("rho",nx3,nx2,nx1);
-  IdefixArray3D<real>::HostMirror rhoHost = Kokkos::create_mirror_view(rho);
+  IdefixArray3D<real>::host_mirror_type rhoHost = Kokkos::create_mirror_view(rho);
 
   // Fill the host array, and compute the theoretical results
   real theoreticalResult = 0;

--- a/test/utils/columnDensity/setup.cpp
+++ b/test/utils/columnDensity/setup.cpp
@@ -33,7 +33,7 @@ void Analysis(DataBlock & data) {
   columnX3Right->ComputeColumn(rho);
 
   IdefixArray3D<real> columnDensityLeft, columnDensityRight;
-  IdefixArray3D<real>::HostMirror columnDensityLeftHost, columnDensityRightHost;
+  IdefixArray3D<real>::host_mirror_type columnDensityLeftHost, columnDensityRightHost;
   // IDIR
   columnDensityLeft = columnX1Left->GetColumn();
   columnDensityRight = columnX1Right->GetColumn();

--- a/test/utils/lookupTable/main.cpp
+++ b/test/utils/lookupTable/main.cpp
@@ -38,7 +38,7 @@ int main( int argc, char* argv[] )
     idfx::cout << "--------------------------------------" << std::endl;
     idfx::cout << "Testing 2D CSV file on device." << std::endl;
     IdefixArray1D<real> arr = IdefixArray1D<real>("Test",1);
-    IdefixArray1D<real>::HostMirror arrHost = Kokkos::create_mirror_view(arr);
+    IdefixArray1D<real>::host_mirror_type arrHost = Kokkos::create_mirror_view(arr);
 
     LookupTable<2> csv("toto.csv",',');
 


### PR DESCRIPTION
This PR contains several fixes to make the test suite passing again after the upgrade to **kokkos-5.1** :

1. Removal of a non required `volatile` keyword in an `operator+=`
2. add pybind11 to `test/python_requirements.txt` as it is used by some tests
3. add a python package pre-install action to build a venv before running the tests suite in github actions
4. Finish to rename some types `HostMirror` => `host_mirror_type`

The test suite is now passing again.