### PR TITLE
Fixing issues related to linking parallel hdf5 on cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include(ReplaceIdefixSource)
 include(AddIdefixSource)
 include(SetIdefixProperty)
 include(SetRequiredBuildSettingsForGCC8)
+include(CheckHdf5ParallelSupport)
 
 #Idefix requires Cuda Lambdas (experimental)
 if(Kokkos_ENABLE_CUDA)
@@ -130,55 +131,8 @@ if(Idefix_HDF5)
   message(STATUS "Found HDF5 include directories: ${HDF5_INCLUDE_DIRS}")
   target_include_directories(idefix PUBLIC "${HDF5_INCLUDE_DIRS}")
   if(Idefix_MPI)
-    include(CheckCSourceCompiles)
-
-    # Some CMake/HDF5 combinations do not reliably set HDF5_IS_PARALLEL
-    # (e.g. when HDF5 is found via its CMake config package rather than the
-    # FindHDF5 module). Combine metadata checks with a compile+link probe for
-    # the MPI-IO symbols to reliably detect parallel HDF5.
-    set(_idefix_hdf5_is_parallel FALSE)
-    if(HDF5_IS_PARALLEL OR HDF5_C_IS_PARALLEL)
-      set(_idefix_hdf5_is_parallel TRUE)
-    endif()
-
-    if(NOT _idefix_hdf5_is_parallel AND DEFINED HDF5_C_COMPILER_EXECUTABLE)
-      execute_process(
-        COMMAND "${HDF5_C_COMPILER_EXECUTABLE}" -showconfig
-        OUTPUT_VARIABLE _idefix_hdf5_showconfig
-        ERROR_QUIET
-      )
-      if(_idefix_hdf5_showconfig MATCHES "Parallel HDF5:[ \t]*yes")
-        set(_idefix_hdf5_is_parallel TRUE)
-      endif()
-    endif()
-
-    set(_idefix_saved_required_includes "${CMAKE_REQUIRED_INCLUDES}")
-    set(_idefix_saved_required_libraries "${CMAKE_REQUIRED_LIBRARIES}")
-
-    set(CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIRS} ${MPI_C_INCLUDE_DIRS})
-    set(CMAKE_REQUIRED_LIBRARIES ${_idefix_hdf5_link_items} MPI::MPI_C)
-    check_c_source_compiles(
-      "#include <mpi.h>
-       #include <hdf5.h>
-       int main(void) {
-         hid_t plist = H5Pcreate(H5P_FILE_ACCESS);
-         H5Pset_fapl_mpio(plist, MPI_COMM_WORLD, MPI_INFO_NULL);
-         H5Pclose(plist);
-         return 0;
-       }"
-      IDEFIX_HDF5_HAS_MPI_IO
-    )
-
-    set(CMAKE_REQUIRED_INCLUDES "${_idefix_saved_required_includes}")
-    set(CMAKE_REQUIRED_LIBRARIES "${_idefix_saved_required_libraries}")
-    unset(_idefix_saved_required_includes)
-    unset(_idefix_saved_required_libraries)
-
-    if(IDEFIX_HDF5_HAS_MPI_IO)
-      set(_idefix_hdf5_is_parallel TRUE)
-    endif()
-
-    if(NOT _idefix_hdf5_is_parallel)
+    CheckHdf5ParallelSupport("${_idefix_hdf5_link_items}")
+    if(NOT IDEFIX_HDF5_IS_PARALLEL)
       message(FATAL_ERROR "Parallel HDF5 required for Idefix_MPI but the found HDF5 library does not support it")
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if(Idefix_HDF5)
 
     if(NOT _idefix_hdf5_is_parallel AND DEFINED HDF5_C_COMPILER_EXECUTABLE)
       execute_process(
-        COMMAND ${HDF5_C_COMPILER_EXECUTABLE} -showconfig
+        COMMAND "${HDF5_C_COMPILER_EXECUTABLE}" -showconfig
         OUTPUT_VARIABLE _idefix_hdf5_showconfig
         ERROR_QUIET
       )
@@ -151,6 +151,9 @@ if(Idefix_HDF5)
         set(_idefix_hdf5_is_parallel TRUE)
       endif()
     endif()
+
+    set(_idefix_saved_required_includes "${CMAKE_REQUIRED_INCLUDES}")
+    set(_idefix_saved_required_libraries "${CMAKE_REQUIRED_LIBRARIES}")
 
     set(CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIRS} ${MPI_C_INCLUDE_DIRS})
     set(CMAKE_REQUIRED_LIBRARIES ${_idefix_hdf5_link_items} MPI::MPI_C)
@@ -165,8 +168,11 @@ if(Idefix_HDF5)
        }"
       IDEFIX_HDF5_HAS_MPI_IO
     )
-    unset(CMAKE_REQUIRED_INCLUDES)
-    unset(CMAKE_REQUIRED_LIBRARIES)
+
+    set(CMAKE_REQUIRED_INCLUDES "${_idefix_saved_required_includes}")
+    set(CMAKE_REQUIRED_LIBRARIES "${_idefix_saved_required_libraries}")
+    unset(_idefix_saved_required_includes)
+    unset(_idefix_saved_required_libraries)
 
     if(IDEFIX_HDF5_HAS_MPI_IO)
       set(_idefix_hdf5_is_parallel TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,12 +113,66 @@ if(Idefix_HDF5)
     PUBLIC src/output/xdmf.cpp
     PUBLIC src/output/xdmf.hpp
   )
-  find_package(HDF5 REQUIRED)
-  target_link_libraries(idefix "${HDF5_LIBRARIES}")
+  # Prefer imported targets (matches older working behavior), then fall back.
+  find_package(HDF5 QUIET COMPONENTS C)
+  if(NOT HDF5_FOUND)
+    find_package(HDF5 REQUIRED MODULE COMPONENTS C)
+  endif()
+
+  set(_idefix_hdf5_link_items "${HDF5_LIBRARIES}")
+  if(TARGET hdf5::hdf5)
+    set(_idefix_hdf5_link_items hdf5::hdf5)
+  elseif(TARGET HDF5::HDF5)
+    set(_idefix_hdf5_link_items HDF5::HDF5)
+  endif()
+
+  target_link_libraries(idefix ${_idefix_hdf5_link_items})
   message(STATUS "Found HDF5 include directories: ${HDF5_INCLUDE_DIRS}")
   target_include_directories(idefix PUBLIC "${HDF5_INCLUDE_DIRS}")
   if(Idefix_MPI)
-    if(NOT HDF5_IS_PARALLEL)
+    include(CheckCSourceCompiles)
+
+    # Some CMake/HDF5 combinations do not reliably set HDF5_IS_PARALLEL
+    # (e.g. when HDF5 is found via its CMake config package rather than the
+    # FindHDF5 module). Combine metadata checks with a compile+link probe for
+    # the MPI-IO symbols to reliably detect parallel HDF5.
+    set(_idefix_hdf5_is_parallel FALSE)
+    if(HDF5_IS_PARALLEL OR HDF5_C_IS_PARALLEL)
+      set(_idefix_hdf5_is_parallel TRUE)
+    endif()
+
+    if(NOT _idefix_hdf5_is_parallel AND DEFINED HDF5_C_COMPILER_EXECUTABLE)
+      execute_process(
+        COMMAND ${HDF5_C_COMPILER_EXECUTABLE} -showconfig
+        OUTPUT_VARIABLE _idefix_hdf5_showconfig
+        ERROR_QUIET
+      )
+      if(_idefix_hdf5_showconfig MATCHES "Parallel HDF5:[ \t]*yes")
+        set(_idefix_hdf5_is_parallel TRUE)
+      endif()
+    endif()
+
+    set(CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIRS} ${MPI_C_INCLUDE_DIRS})
+    set(CMAKE_REQUIRED_LIBRARIES ${_idefix_hdf5_link_items} MPI::MPI_C)
+    check_c_source_compiles(
+      "#include <mpi.h>
+       #include <hdf5.h>
+       int main(void) {
+         hid_t plist = H5Pcreate(H5P_FILE_ACCESS);
+         H5Pset_fapl_mpio(plist, MPI_COMM_WORLD, MPI_INFO_NULL);
+         H5Pclose(plist);
+         return 0;
+       }"
+      IDEFIX_HDF5_HAS_MPI_IO
+    )
+    unset(CMAKE_REQUIRED_INCLUDES)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+
+    if(IDEFIX_HDF5_HAS_MPI_IO)
+      set(_idefix_hdf5_is_parallel TRUE)
+    endif()
+
+    if(NOT _idefix_hdf5_is_parallel)
       message(FATAL_ERROR "Parallel HDF5 required for Idefix_MPI but the found HDF5 library does not support it")
     endif()
   endif()

--- a/cmake/CheckHdf5ParallelSupport.cmake
+++ b/cmake/CheckHdf5ParallelSupport.cmake
@@ -1,0 +1,50 @@
+include(CheckCSourceCompiles)
+
+# Check whether the HDF5 library found by find_package(HDF5) supports parallel
+# (MPI-IO) access, and store the result in IDEFIX_HDF5_IS_PARALLEL in the
+# caller's scope.
+#
+# Usage: CheckHdf5ParallelSupport(<hdf5_link_items>)
+# where <hdf5_link_items> is the list of HDF5 targets/libraries to link against.
+#
+# Some CMake/HDF5 combinations do not reliably set HDF5_IS_PARALLEL (e.g. when
+# HDF5 is found via its CMake config package rather than the FindHDF5 module).
+# Combine metadata checks with a compile+link probe for the MPI-IO symbols to
+# reliably detect parallel HDF5.
+function(CheckHdf5ParallelSupport hdf5_link_items)
+  set(_idefix_hdf5_is_parallel FALSE)
+  if(HDF5_IS_PARALLEL OR HDF5_C_IS_PARALLEL)
+    set(_idefix_hdf5_is_parallel TRUE)
+  endif()
+
+  if(NOT _idefix_hdf5_is_parallel AND DEFINED HDF5_C_COMPILER_EXECUTABLE)
+    execute_process(
+      COMMAND "${HDF5_C_COMPILER_EXECUTABLE}" -showconfig
+      OUTPUT_VARIABLE _idefix_hdf5_showconfig
+      ERROR_QUIET
+    )
+    if(_idefix_hdf5_showconfig MATCHES "Parallel HDF5:[ \t]*yes")
+      set(_idefix_hdf5_is_parallel TRUE)
+    endif()
+  endif()
+
+  set(CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIRS} ${MPI_C_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_LIBRARIES ${hdf5_link_items} MPI::MPI_C)
+  check_c_source_compiles(
+    "#include <mpi.h>
+     #include <hdf5.h>
+     int main(void) {
+       hid_t plist = H5Pcreate(H5P_FILE_ACCESS);
+       H5Pset_fapl_mpio(plist, MPI_COMM_WORLD, MPI_INFO_NULL);
+       H5Pclose(plist);
+       return 0;
+     }"
+    IDEFIX_HDF5_HAS_MPI_IO
+  )
+
+  if(IDEFIX_HDF5_HAS_MPI_IO)
+    set(_idefix_hdf5_is_parallel TRUE)
+  endif()
+
+  set(IDEFIX_HDF5_IS_PARALLEL ${_idefix_hdf5_is_parallel} PARENT_SCOPE)
+endfunction()

--- a/src/fluid/boundary/axis.cpp
+++ b/src/fluid/boundary/axis.cpp
@@ -392,8 +392,8 @@ void Axis::ExchangeMPI(int side) {
   idfx::pushRegion("Axis::ExchangeMPI");
   #ifdef WITH_MPI
   // Load  the buffers with data
-  int ibeg,iend,jbeg,jend,kbeg,kend,offset;
-  int ny;
+  [[maybe_unused]] int ibeg,iend,jbeg,jend,kbeg,kend,offset;
+  [[maybe_unused]] int ny;
   Buffer bufferSend = this->bufferSend;
   IdefixArray1D<int> map = this->mapVars;
   IdefixArray4D<real> Vc = this->Vc;

--- a/src/fluid/showConfig.hpp
+++ b/src/fluid/showConfig.hpp
@@ -60,7 +60,7 @@ void Fluid<Phys>::ShowConfig() {
                  << ": Ohmic resistivity ENABLED with user-defined resistivity function."
                  << std::endl;
       if(!ohmicDiffusivityFunc) {
-        IDEFIX_ERROR("No user-defined Ihmic resistivity function has been enrolled.");
+        IDEFIX_ERROR("No user-defined Ohmic resistivity function has been enrolled.");
       }
     } else {
       IDEFIX_ERROR("Unknown Ohmic resistivity mode");

--- a/src/output/xdmf.cpp
+++ b/src/output/xdmf.cpp
@@ -295,7 +295,7 @@ int Xdmf::Write() {
   #if DIMENSIONS == 1
   [[maybe_unused]] int tot_dim = 1;
   #elif DIMENSIONS == 2
-  int tot_dim = 2;
+  [[maybe_unused]] int tot_dim = 2;
   #elif DIMENSIONS == 3
   [[maybe_unused]] int tot_dim = 3;
   #endif


### PR DESCRIPTION
On our Freya cluster at MPCDF, I tried compiling Idefix using the following after setting `IDEFIX_DIR`:
```
module purge
module load gcc/15 cuda/13.0 cmake/4.0
OMPI=/freya/ptmp/mpa/adutt/openmpi_gpu-5.0
HDF5=/freya/ptmp/mpa/adutt/hdf5-2.0.0-openmpi_gpu-5.0/parallel
export PATH=$OMPI/bin:$HDF5/bin:$PATH
export LD_LIBRARY_PATH=$OMPI/lib:$HDF5/lib:${LD_LIBRARY_PATH:-}

CC=mpicc CXX=mpic++ cmake  \
-DIdefix_MPI=ON -DIdefix_DEBUG=OFF \
-DIdefix_HDF5=ON   -DKokkos_ENABLE_CUDA=ON \
-DKokkos_ARCH_AMPERE80=ON \
-DHDF5_ROOT=/freya/ptmp/mpa/adutt/hdf5-2.0.0-openmpi_gpu-5.0/parallel \
-DIdefix_PROBLEM_DIR=$PWD \
-GNinja -B ./build -S $IDEFIX_DIR  
cmake --build ./build/
```
This resulted in an error in linking hdf5 library. Following is the error message:
```
-- Found HDF5: hdf5-shared (found version "2.0.0")
-- Found HDF5 include directories: /freya/ptmp/mpa/adutt/hdf5-2.0.0-openmpi_gpu-5.0/parallel/include
CMake Error at CMakeLists.txt:122 (message):
  Parallel HDF5 required for Idefix_MPI but the found HDF5 library does not
  support it
  ```
  This comes up despite having parallel support enabled hdf5 library. This PR addresses the issue and introduces a robust hdf5 linking section in `CMakeLists.txt`.
  Apart from this, there are two minor edits to suppress unused variable warnings.