### PR TITLE
TST: require inifile to be Pluto/Idefix valid

### DIFF
--- a/test/MHD/Coarsening/python/testidefix.py
+++ b/test/MHD/Coarsening/python/testidefix.py
@@ -34,7 +34,7 @@ with open("../idefix.0.log", "r") as fp:
             s = line.split()
             inputFile = s[5][:-1]
 
-input = inifix.load("../" + inputFile)
+input = inifix.load(f"../{inputFile}", sections="require")
 componentDir = input["Setup"]["direction"][0]
 spatialDir = input["Setup"]["direction"][1]
 

--- a/test/MHD/MTI/python/testidefix.py
+++ b/test/MHD/MTI/python/testidefix.py
@@ -16,7 +16,7 @@ import numpy as np
 
 n = 1  # fondamental mode
 
-conf = inifix.load("../idefix.ini")
+conf = inifix.load("../idefix.ini", sections="require")
 Pr = conf["Setup"]["pr"]
 ksi = conf["Setup"]["ksi"]
 

--- a/test/MHD/clessTDiffusion/python/testidefix.py
+++ b/test/MHD/clessTDiffusion/python/testidefix.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pytools.vtk_io import readVTK
 
-conf = inifix.load("../idefix.ini")
+conf = inifix.load("../idefix.ini", sections="require")
 gamma = conf["Hydro"]["gamma"]
 kappa = conf["Hydro"]["bragTDiffusion"][-1]
 

--- a/test/MHD/sphBragTDiffusion/python/testidefix.py
+++ b/test/MHD/sphBragTDiffusion/python/testidefix.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pytools.vtk_io import readVTK
 
-conf = inifix.load("../idefix.ini")
+conf = inifix.load("../idefix.ini", sections="require")
 amplitude = conf["Setup"]["amplitude"]
 gamma = conf["Hydro"]["gamma"]
 kappa = conf["Hydro"]["bragTDiffusion"][-1]

--- a/test/MHD/sphBragViscosity/python/testidefix.py
+++ b/test/MHD/sphBragViscosity/python/testidefix.py
@@ -8,7 +8,7 @@ from scipy.special import jn
 
 from pytools.vtk_io import readVTK
 
-conf = inifix.load("../idefix.ini")
+conf = inifix.load("../idefix.ini", sections="require")
 amplitude = conf["Setup"]["amplitude"]
 time_step = conf["Output"]["vtk"]
 

--- a/test/python_requirements.txt
+++ b/test/python_requirements.txt
@@ -1,13 +1,12 @@
-# note: version requirements are indicative and tests # should be able to run with
+# note: version requirements are indicative and tests should be able to run with
 # older versions of our dependencies, though it is not guaranteed.
 
-# minimally require last versions available for Python 2.7
-numpy>=1.16.6
-matplotlib>=2.2.5
-scipy>=1.2.3
-
-# note that no version of inifix supports Python older than 3.6
+# minimally require earliest versions available for Python 3.10
+numpy>=1.21.1
+matplotlib>=3.5.0
+scipy>=1.7.2
 inifix>=0.11.2
+
 pybind11 >= 3.0.4
 # To run the test suite, we can use pytest, mostly any version
 # 6.0 is the one available on system available on debian-11

--- a/test/python_requirements.txt
+++ b/test/python_requirements.txt
@@ -5,7 +5,7 @@
 numpy>=1.21.1
 matplotlib>=3.5.0
 scipy>=1.7.2
-inifix>=0.11.2
+inifix>=5.1.0
 
 pybind11 >= 3.0.4
 # To run the test suite, we can use pytest, mostly any version


### PR DESCRIPTION
Based off #393
This rejects sectionless files otherwise supported by `inifix.load` (such as fargo-like param files)
