### PR TITLE
test: Fix missing propagation of return status when calling pytest in ./test.py

### DIFF
--- a/doc/source/testing/testLauncher.rst
+++ b/doc/source/testing/testLauncher.rst
@@ -191,6 +191,12 @@ In addition there is some extra keys which are dedicated to the json interpretat
    * - ``multirun``
      - ``{}``
      - See the multi-run section below.
+   * - ``callPyFunctionBefore``
+     -
+     - Call a python function before executing the test (see dedicated section at the end of this file).
+   * - ``callPyFunctionAfter``
+     -
+     - Call a python function after executing the test (see dedicated section at the end of this file).
 
 Looping over parameters
 -----------------------
@@ -372,6 +378,33 @@ They are described like :
                 }
             ]
         },
+    }
+
+Calling a Python function
+-------------------------
+
+In some cases (example in ``test/utils/lookupTable``) you might need to call a custom
+python function before running the test to prepare the data or after the test to perform
+some extra check.
+
+You can simply implement the functions you want to call in the python file in the test
+directory (ideally named ``testmelib.py``) :
+
+.. code-block:: python
+
+    def callMeAtStart():
+        print("This is called at test start !")
+
+    def callMeAtEnd():
+        print("This is called at test end !")
+
+And add the keys in ``testme.json``:
+
+.. code-block:: json
+
+    "default": {
+        "callPyFunctionBefore": "testmelib.py:callMeAtStart",
+        "callPyFunctionAfter": "testmelib.py:callMeAtEnd"
     }
 
 Using the idfxTest options

--- a/pytools/idfx_test_run.py
+++ b/pytools/idfx_test_run.py
@@ -227,7 +227,8 @@ class IdexPytestRunner:
             del config[f"callPyFunction{hook}"]
 
         # call hook before
-        self.callPyHook(problemDir, pyHooks, "Before")
+        with moveInDir(problemDir):
+            self.callPyHook(problemDir, pyHooks, "Before")
 
         # if switch from test, rebuild the runner (a runner make for one dir)
         if self.currentTestFile != testfile:
@@ -255,7 +256,8 @@ class IdexPytestRunner:
                 )
 
         # call hook after
-        self.callPyHook(problemDir, pyHooks, "After")
+        with moveInDir(problemDir):
+            self.callPyHook(problemDir, pyHooks, "After")
 
     def _runNonRegression(
         self,

--- a/pytools/idfx_test_run.py
+++ b/pytools/idfx_test_run.py
@@ -249,11 +249,12 @@ class IdexPytestRunner:
             )
 
         # check produced
-        for file in check_file_produced:
-            if not os.path.exists(file) and not self.currentTestRunner.fake:
-                raise Exception(
-                    f"Don't find expected file to be produced by the run : {file} !"
-                )
+        with moveInDir(problemDir):
+            for file in check_file_produced:
+                if not os.path.exists(file) and not self.currentTestRunner.fake:
+                    raise Exception(
+                        f"Don't find expected file to be produced by the run : {file} !"
+                    )
 
         # call hook after
         with moveInDir(problemDir):

--- a/pytools/idfx_test_run.py
+++ b/pytools/idfx_test_run.py
@@ -7,6 +7,7 @@
 
 import copy
 import glob
+import importlib
 import json
 import os
 import sys
@@ -135,6 +136,58 @@ class IdexPytestRunner:
         # ok
         return result
 
+    def buildPyHooks(self, config: dict) -> dict:
+        # init
+        result = {}
+        key: str
+
+        # extract and build dict
+        for key, value in config.items():
+            if key.startswith("callPyFunction"):
+                when = key.replace("callPyFunction", "")
+                result[when] = value
+
+        # ok
+        return result
+
+    # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+    def importFromPath(self, moduleName: str, filePath: str):
+        spec = importlib.util.spec_from_file_location(moduleName, filePath)
+        module = importlib.util.module_from_spec(spec)
+        # sys.modules[moduleName] = module
+        spec.loader.exec_module(module)
+        return module
+
+    def callPyHook(self, dir: str, hooks: dict, name: str) -> None:
+        # nothing to do
+        if name not in hooks:
+            return
+
+        # split file:funcName
+        params = hooks[name].split(":", 1)
+        filePath = params[0]
+        funcName = params[1]
+
+        # complete
+        fileFullPath = os.path.join(dir, filePath)
+
+        # log
+        print("************** CALLING PY FUNCTION ****************")
+        print(f"Hook: {name}")
+        print(f"HookValue: {hooks[name]}")
+        print(f"Import {fileFullPath}")
+        print(f"Call: {funcName}")
+        print("***************************************************")
+
+        # import the module
+        module = self.importFromPath("idefix_test_py_hooks", fileFullPath)
+
+        # get function
+        function = getattr(module, funcName)
+
+        # call it
+        function()
+
     def run(self, config: dict) -> None:
         # clone before modify to not modity for caller
         config = copy.deepcopy(config)
@@ -155,6 +208,7 @@ class IdexPytestRunner:
         nonRegressionTestIni = config.get("nonRegressionTestIni", None)
         check_file_produced = config.get("check_file_produced", [])
         problemDir = os.path.dirname(testfile)
+        pyHooks = self.buildPyHooks(config)
 
         # cleanup some keyword not handled at the
         # level of idx_test so we don't perturbate it
@@ -169,6 +223,11 @@ class IdexPytestRunner:
             del config["nonRegressionTest"]
         if "nonRegressionTestIni" in config:
             del config["nonRegressionTestIni"]
+        for hook in pyHooks:
+            del config[f"callPyFunction{hook}"]
+
+        # call hook before
+        self.callPyHook(problemDir, pyHooks, "Before")
 
         # if switch from test, rebuild the runner (a runner make for one dir)
         if self.currentTestFile != testfile:
@@ -194,6 +253,9 @@ class IdexPytestRunner:
                 raise Exception(
                     f"Don't find expected file to be produced by the run : {file} !"
                 )
+
+        # call hook after
+        self.callPyHook(problemDir, pyHooks, "After")
 
     def _runNonRegression(
         self,

--- a/pytools/idfx_test_run.py
+++ b/pytools/idfx_test_run.py
@@ -365,7 +365,7 @@ class IdexPytestRunner:
         os.environ["IDEFIX_TEST_FILTER_SUBDIR"] = idefixTest.filterSubdir
 
         if idefixTest.all:
-            pytest.main(
+            status = pytest.main(
                 [
                     "-v",
                     "--no-header",
@@ -375,6 +375,7 @@ class IdexPytestRunner:
                 + idefixTest.remainingArgs
                 + [self.parentScritFile]
             )
+            sys.exit(status)
         else:
             raise NotImplementedError("Not yet supported !")
         # elif self.check:

--- a/src/fluid/RiemannSolver/MHDsolvers/storeFlux.hpp
+++ b/src/fluid/RiemannSolver/MHDsolvers/storeFlux.hpp
@@ -55,8 +55,8 @@ KOKKOS_FORCEINLINE_FUNCTION void K_StoreHLL( const int i, const int j, const int
                                         const IdefixArray3D<real> &dL,
                                         const IdefixArray3D<real> &dR) {
   EXPAND(                                          ,
-        constexpr int Xt = (DIR == IDIR ? MX2 : MX1);  ,
-        constexpr int Xb = (DIR == KDIR ? MX2 : MX3);  )
+        [[maybe_unused]] constexpr int Xt = (DIR == IDIR ? MX2 : MX1);  ,
+        [[maybe_unused]] constexpr int Xb = (DIR == KDIR ? MX2 : MX3);  )
 
   real ar = std::fmax(ZERO_F, sr);
   real al = std::fmin(ZERO_F, sl);

--- a/src/fluid/boundary/axis.cpp
+++ b/src/fluid/boundary/axis.cpp
@@ -392,7 +392,8 @@ void Axis::ExchangeMPI(int side) {
   idfx::pushRegion("Axis::ExchangeMPI");
   #ifdef WITH_MPI
   // Load  the buffers with data
-  int ibeg,iend,jbeg,jend,kbeg,kend,offset;
+  [[maybe_unused]] int ibeg,iend,jbeg,jend,kbeg,kend;
+  int offset;
   int ny;
   Buffer bufferSend = this->bufferSend;
   IdefixArray1D<int> map = this->mapVars;

--- a/src/fluid/boundary/axis.cpp
+++ b/src/fluid/boundary/axis.cpp
@@ -491,12 +491,12 @@ void Axis::ExchangeMPI(int side) {
       //unpack Vs face-centered
       BoundingBox recvBoxVsIdir = baseBox;
       recvBoxVsIdir[IDIR][1] += 1;
-      bufferRecv.UnpackJDirSymetric(Vs, IDIR, sVs(IDIR), recvBoxVsIdir);
+      bufferRecv.UnpackJDirSymetric(Vs, IDIR, sVs, recvBoxVsIdir);
 
       //unpack Vs face-centered
       BoundingBox recvBoxVsKdir = baseBox;
       recvBoxVsKdir[KDIR][1] += 1;
-      bufferRecv.UnpackJDirSymetric(Vs, KDIR, sVs(KDIR), recvBoxVsKdir);
+      bufferRecv.UnpackJDirSymetric(Vs, KDIR, sVs, recvBoxVsKdir);
     }
   } else if(side==right) {
     //unpack Vc on right part
@@ -514,14 +514,14 @@ void Axis::ExchangeMPI(int side) {
       recvBoxVsIdir[IDIR][1] += 1;
       recvBoxVsIdir[JDIR][0] += offset;
       recvBoxVsIdir[JDIR][1] += offset;
-      bufferRecv.UnpackJDirSymetric(Vs, IDIR, sVs(IDIR), recvBoxVsIdir);
+      bufferRecv.UnpackJDirSymetric(Vs, IDIR, sVs, recvBoxVsIdir);
 
       //unpack Vs face-centered on right part
       BoundingBox recvBoxVsKdir = baseBox;
       recvBoxVsKdir[KDIR][1] += 1;
       recvBoxVsKdir[JDIR][0] += offset;
       recvBoxVsKdir[JDIR][1] += offset;
-      bufferRecv.UnpackJDirSymetric(Vs, KDIR, sVs(KDIR), recvBoxVsKdir);
+      bufferRecv.UnpackJDirSymetric(Vs, KDIR, sVs, recvBoxVsKdir);
     } // MHD
   }
 

--- a/src/fluid/constrainedTransport/EMFexchange.hpp
+++ b/src/fluid/constrainedTransport/EMFexchange.hpp
@@ -75,7 +75,7 @@ void ConstrainedTransport<Phys>::ExchangeX1(IdefixArray3D<real> ey, IdefixArray3
   sendBoxEy[KDIR][1] += 1;
   sendBoxEy[IDIR][0] = iright;
   sendBoxEy[IDIR][1] = iright + 1;
-  BufferRight.Pack(ez, sendBoxEy);
+  BufferRight.Pack(ey, sendBoxEy);
   #endif
 
   // Wait for completion before sending out everything
@@ -239,11 +239,11 @@ void ConstrainedTransport<Phys>::ExchangeX3(IdefixArray3D<real> ex, IdefixArray3
   baseBox[KDIR][1] = data->end[KDIR];
 
   //extend by one the end on jdir && take the ghost on k
-  BoundingBox sendBoxEz = baseBox;
-  sendBoxEz[JDIR][1] += 1;
-  sendBoxEz[KDIR][0] = kright;
-  sendBoxEz[KDIR][1] = kright + 1;
-  BufferRight.Pack(ez, sendBoxEz);
+  BoundingBox sendBoxEx = baseBox;
+  sendBoxEx[JDIR][1] += 1;
+  sendBoxEx[KDIR][0] = kright;
+  sendBoxEx[KDIR][1] = kright + 1;
+  BufferRight.Pack(ex, sendBoxEx);
 
   //extend by one the end on idir && take the ghost on k
   BoundingBox sendBoxEy = baseBox;

--- a/src/mpi/buffer.hpp
+++ b/src/mpi/buffer.hpp
@@ -165,7 +165,7 @@ class Buffer {
 
   void UnpackJDirSymetric(IdefixArray4D<real>& out,
         const int var,
-        const int symMultiplier,
+        IdefixArray1D<int>& SymMap,
         BoundingBox box) {
     const int ni = box[IDIR][1]-box[IDIR][0];
     const int ninj = (box[JDIR][1]-box[JDIR][0])*ni;
@@ -183,6 +183,7 @@ class Buffer {
       KOKKOS_LAMBDA (int k, int j, int i) {
         const int jinverted = jend-(j-jbeg)-1;
         const int arrIndex = i-ibeg + (j-jbeg)*ni + (k-kbeg)*ninj + offset;
+        const int symMultiplier = SymMap(var);
         out(var,k,jinverted,i) = symMultiplier * arr(arrIndex);
     });
 

--- a/test/utils/lookupTable/testme.json
+++ b/test/utils/lookupTable/testme.json
@@ -4,6 +4,7 @@
         "ini": "idefix.ini",
         "nonRegressionTest": false,
         "standardTest": false,
-        "tolerance": 0
+        "tolerance": 0,
+        "callPyFunctionBefore": "testmelib.py:MakeNumpyFile"
     }
 }

--- a/test/utils/lookupTable/testme.py
+++ b/test/utils/lookupTable/testme.py
@@ -9,32 +9,13 @@ import os
 import sys
 
 sys.path.append(os.getenv("IDEFIX_DIR"))
-import numpy as np
-
 # from scipy.interpolate import RegularGridInterpolator
+import testmelib
+
 import pytools.idfx_test as tst
 
-
-def MakeNumpyFile():
-    x = np.arange(1, 10, 1.0)
-    y = np.arange(5, 10, 1.0)
-    z = np.arange(2, 5, 1.0)
-
-    xp, yp, zp = np.meshgrid(x, y, z, indexing="ij")
-
-    data = xp + 2 * yp - zp
-
-    np.save("x.npy", x)
-    np.save("y.npy", y)
-    np.save("z.npy", z)
-    np.save("data.npy", data)
-    # show the expected result
-    # f=RegularGridInterpolator((x, y, z), data)
-    # print(f([2.7,7.4,3.9]))
-
-
 test = tst.idfxTest(__file__)
-MakeNumpyFile()
+testmelib.MakeNumpyFile()
 
 test.configure()
 test.compile()

--- a/test/utils/lookupTable/testmelib.py
+++ b/test/utils/lookupTable/testmelib.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+
+def MakeNumpyFile():
+    x = np.arange(1, 10, 1.0)
+    y = np.arange(5, 10, 1.0)
+    z = np.arange(2, 5, 1.0)
+
+    xp, yp, zp = np.meshgrid(x, y, z, indexing="ij")
+
+    data = xp + 2 * yp - zp
+
+    np.save("x.npy", x)
+    np.save("y.npy", y)
+    np.save("z.npy", z)
+    np.save("data.npy", data)
+    # show the expected result
+    # f=RegularGridInterpolator((x, y, z), data)
+    # print(f([2.7,7.4,3.9]))


### PR DESCRIPTION
Big ooops, forgot to return the pytest status to propagate it as it does not throw an exception.

Also fix issues to make the test suite green again : 

* Access to a GPU cell from CPU in previous communication refactoring.
* Missing call to a python function for a test
* Wrong array used in a previous refactoring about MPI communications.
* Fix a warning due to unused variable

Python call in testme.json
=====================

In order to fix the missing call the `MakeNumpyFile()` function in the test `test/utils/lookupTable` I added in this PR a new semantic in the test suite to be able to call a Python function from the `testme.json` test definition.

It is simply two new fields which can be used : 

```json
 "default": {
    "callPyFunctionBefore": "testmelib.py:callMeAtStart",
    "callPyFunctionAfter": "testmelib.py:callMeAtEnd"
}
```

It will call `callMeAtStart` before running the test and `callMeAtEnd` at the end of the test, the two functions beeing defined in `testmelib.py`.

**Note**: the documentation has been updated.