### PR TITLE
github: update the github-action versions to fix some warnings about nodejs-20 instead of nodejs-24

### DIFF
--- a/.github/workflows/idefix-ci-doc.yml
+++ b/.github/workflows/idefix-ci-doc.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: install doxygen

--- a/.github/workflows/idefix-ci-jobs.yml
+++ b/.github/workflows/idefix-ci-jobs.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -47,7 +47,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -64,7 +64,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -87,7 +87,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -109,7 +109,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -125,7 +125,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -141,7 +141,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -163,7 +163,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -187,7 +187,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -203,7 +203,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -223,7 +223,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -237,7 +237,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -255,7 +255,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/idefix-ci.yml
+++ b/.github/workflows/idefix-ci.yml
@@ -17,14 +17,14 @@ jobs:
     if: ${{ github.repository == 'idefix-code/idefix' || github.repository == 'glesur/idefix' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
-      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
-      - uses: pre-commit-ci/lite-action@50143aaf27e2c42e75a5e06185a471d9582e89df # v1.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
         if: always()
 
   icc-jobs:


### PR DESCRIPTION
Target
=====

Try to avoid the warning about NodeJS-20 instead of NodeJS-24 in github actions.

In theory updating the versions of the action libraries used in the project should avoid the warning.

I updated to last release available : 

- actions/checkout : 3.6.0 -> **7.0.1**
- actions/setup-python : 4.9.1 -> **6.3.0** (there is a 7.0.0 just released one month ago, but I preferred to used the last stable one).
-  pre-commit/action : 3.0.0 -> **3.0.1**
-  pre-commit-ci/lite-action : 1.0.0 -> **1.0.1**

Pointers
=======

Migration to NodeJS-24 is effective since **16 june 2026** : https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Warning solved
=============

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v3, actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744, actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c, pre-commit-ci/lite-action@50143aaf27e2c42e75a5e06185a471d9582e89df. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

Still
===

The port to NodeJS-24 is not yet done "a priori" for `pre-commit-ci/lite-action` so the upgrade do not solve it. To be seen later.