### PR TITLE
Move CheckNan to end of loop on stages in timeIntegrator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,6 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=100'] ## prevent files larger than 100kB from being commited (exclude git lfs files)
 
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.23.1
-    hooks:
-    - id: zizmor
-
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.2
     hooks:
@@ -45,10 +40,9 @@ repos:
         - F403 # ignore import *
 
   - repo: https://github.com/neutrinoceros/inifix
-    rev: v6.1.2
+    rev: v5.0.2
     hooks:
       - id: inifix-format
-        files: ^(test/).*\.(ini)$ # want to skip pytest.ini
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=100'] ## prevent files larger than 100kB from being commited (exclude git lfs files)
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.23.1
+    hooks:
+    - id: zizmor
+
   - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
     rev: v1.1.2
     hooks:
@@ -40,9 +45,10 @@ repos:
         - F403 # ignore import *
 
   - repo: https://github.com/neutrinoceros/inifix
-    rev: v5.0.2
+    rev: v6.1.2
     hooks:
       - id: inifix-format
+        files: ^(test/).*\.(ini)$ # want to skip pytest.ini
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5

--- a/src/timeIntegrator.cpp
+++ b/src/timeIntegrator.cpp
@@ -339,15 +339,7 @@ void TimeIntegrator::Cycle(DataBlock &data) {
 
     // Add back fargo velocity so that boundary conditions are applied on the total V
     if(data.haveFargo) data.fargo->AddVelocity(data.t);
- 
-    // Look for Nans every now and then (this actually cost a lot of time on GPUs
-    // because streams are divergent)
-    if(ncycles%checkNanPeriodicity==0) {
-      if(data.CheckNan()>0) {
-        throw std::runtime_error(std::string("Nan found after integration cycle"));
-      }
-    }
- }
+  }
   /////////////////////////////////////////////////
   // END STAGES LOOP                             //
   /////////////////////////////////////////////////
@@ -375,6 +367,14 @@ void TimeIntegrator::Cycle(DataBlock &data) {
 
   // Launch user step last
   data.LaunchUserStepLast();
+
+  // Look for Nans every now and then (this actually cost a lot of time on GPUs
+  // because streams are divergent)
+  if(ncycles%checkNanPeriodicity==0) {
+    if(data.CheckNan()>0) {
+      throw std::runtime_error(std::string("Nan found after integration cycle"));
+    }
+  }
 
   // Update current time (should have already been done, but this gets rid of roundoff errors)
   data.t=t0+data.dt;

--- a/src/timeIntegrator.cpp
+++ b/src/timeIntegrator.cpp
@@ -339,7 +339,7 @@ void TimeIntegrator::Cycle(DataBlock &data) {
 
     // Add back fargo velocity so that boundary conditions are applied on the total V
     if(data.haveFargo) data.fargo->AddVelocity(data.t);
- 
+
     // Look for Nans every now and then (this actually cost a lot of time on GPUs
     // because streams are divergent)
     if(ncycles%checkNanPeriodicity==0) {

--- a/src/timeIntegrator.cpp
+++ b/src/timeIntegrator.cpp
@@ -301,14 +301,6 @@ void TimeIntegrator::Cycle(DataBlock &data) {
     // evolve dt accordingly
     data.t += data.dt;
 
-    // Look for Nans every now and then (this actually cost a lot of time on GPUs
-    // because streams are divergent)
-    if(ncycles%checkNanPeriodicity==0) {
-      if(data.CheckNan()>0) {
-        throw std::runtime_error(std::string("Nan found after integration cycle"));
-      }
-    }
-
     // Compute next time_step during first stage
     if(stage==0) {
       if(!haveFixedDt) {
@@ -347,7 +339,15 @@ void TimeIntegrator::Cycle(DataBlock &data) {
 
     // Add back fargo velocity so that boundary conditions are applied on the total V
     if(data.haveFargo) data.fargo->AddVelocity(data.t);
-  }
+ 
+    // Look for Nans every now and then (this actually cost a lot of time on GPUs
+    // because streams are divergent)
+    if(ncycles%checkNanPeriodicity==0) {
+      if(data.CheckNan()>0) {
+        throw std::runtime_error(std::string("Nan found after integration cycle"));
+      }
+    }
+ }
   /////////////////////////////////////////////////
   // END STAGES LOOP                             //
   /////////////////////////////////////////////////


### PR DESCRIPTION
CheckNan was previously located after EvolveStage. However, EvolveStage updates the conservative variables and CheckNan checks the primitive variables. This delays the detection of a NaN to the next cycle. By moving CheckNan to the end of the loop on stages in timeIntegrator, so after the ConsToPrim, this PR ensures that we detect the NaN at the cycle where it was created.