### PR TITLE
fix: typo in documentation + issue in pytest configuration

### DIFF
--- a/doc/source/testing/testLauncher.rst
+++ b/doc/source/testing/testLauncher.rst
@@ -32,12 +32,12 @@ To run the test you can basically :
     # Run all tests
     ./test.py
 
-    # Run all tests in ./tests/HD
-    ./test.py -subdir=./tests/HD
+    # Run all tests in ./test/HD
+    ./test.py -subdir=./test/HD
 
     # Select in more details the tests containing the "single" keyword
     # See pytest documentation for the exact advanced semantic
-    ./test.py -subdir=./tests/HD -k single
+    ./test.py -subdir=./test/HD -k single
 
     # Run in verbose
     ./test.py -v

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 markers=
   default: Test to run by default.
 python_files="test_*.py"
-junit_logging="all"
-junit_log_passing_tests=false
+junit_logging=all
+junit_log_passing_tests=False


### PR DESCRIPTION
Two minor fixes in this PR : 

Documentation
-----------------------

Fix typo in documentation of the tests : `./tests/.....` should be `./test/......`.

Pytest
---------

Wrong value formatting in the `pytest.ini` config file made such that the output stream was not captured for failed tests in the `.junit.xml` report file as it should.